### PR TITLE
Add support for fiat currencies

### DIFF
--- a/dia-batching-server/src/args.rs
+++ b/dia-batching-server/src/args.rs
@@ -1,5 +1,17 @@
 use structopt::StructOpt;
 
+fn parse_currency_vec(src: &str) -> SupportedCurrencies {
+	let mut vec = Vec::new();
+	for s in src.split(',') {
+		vec.push(s.to_string());
+	}
+	SupportedCurrencies(vec)
+}
+
+// We need the extra struct to be able to parse the currencies to a Vec
+#[derive(Debug)]
+pub struct SupportedCurrencies(pub Vec<String>);
+
 #[derive(Debug, StructOpt)]
 #[structopt(name = "dia-batching-server", about = "An server for batching requests to the Dia API")]
 pub struct DiaApiArgs {
@@ -13,6 +25,6 @@ pub struct DiaApiArgs {
 
 	/// Currencies to support
 	/// Each currency needs to have the format <blockchain>:<symbol>
-	#[structopt(short, long, default_value = "Vec::default()")]
-	pub supported_currencies: Option<Vec<String>>,
+	#[structopt(short, long, parse(from_str = parse_currency_vec), default_value = "Polkadot:DOT,FIAT:MXN,FIAT:USD")]
+	pub supported_currencies: SupportedCurrencies,
 }

--- a/dia-batching-server/src/args.rs
+++ b/dia-batching-server/src/args.rs
@@ -28,7 +28,7 @@ pub struct DiaApiArgs {
 	/// Fiat currencies need to have the format FIAT:<from>-<to>
 	#[structopt(short, long,
       parse(from_str = parse_currency_vec),
-      default_value = "Polkadot:DOT,Kusama:KSM,FIAT:MXN-USD,FIAT:USD-USD"
+      default_value = "Polkadot:DOT,Kusama:KSM,Stellar:XLM,FIAT:USD-USD,FIAT:MXN-USD,FIAT:BRL-USD"
     )]
 	pub supported_currencies: SupportedCurrencies,
 }

--- a/dia-batching-server/src/args.rs
+++ b/dia-batching-server/src/args.rs
@@ -25,6 +25,10 @@ pub struct DiaApiArgs {
 
 	/// Currencies to support
 	/// Each currency needs to have the format <blockchain>:<symbol>
-	#[structopt(short, long, parse(from_str = parse_currency_vec), default_value = "Polkadot:DOT,FIAT:MXN,FIAT:USD")]
+	/// Fiat currencies need to have the format FIAT:<from>-<to>
+	#[structopt(short, long,
+      parse(from_str = parse_currency_vec),
+      default_value = "Polkadot:DOT,Kusama:KSM,FIAT:MXN-USD,FIAT:USD-USD"
+    )]
 	pub supported_currencies: SupportedCurrencies,
 }

--- a/dia-batching-server/src/dia.rs
+++ b/dia-batching-server/src/dia.rs
@@ -148,16 +148,14 @@ impl DiaApi for Dia {
 	) -> Result<Quotation, Box<dyn error::Error + Send + Sync>> {
 		let QuotedAsset { asset, volume: _ } = asset;
 
-		if asset.blockchain == "FIAT" && asset.symbol == "USD" {
+		if asset.blockchain.to_uppercase() == "FIAT" && asset.symbol.to_uppercase() == "USD-USD" {
 			return Ok(Quotation::get_default_fiat_usd_quotation());
 		}
 
-		let r = if asset.blockchain == "FIAT" {
-			// We assume here that our base currency will always be USD
-			const TARGET_CURRENCY: &str = "USD";
-			// Note that the order is important here. We want the 'fiat to USD' price
-			let fiat_quote = &format!("{}-{}", asset.symbol, TARGET_CURRENCY);
-			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_quote))
+		let r = if asset.blockchain.to_uppercase() == "FIAT" {
+			// The fiat symbol should be of form `{base}-{target}` (e.g. "MXN-USD") for the API to work
+			let fiat_symbol = asset.symbol.to_uppercase();
+			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_symbol))
 				.await?
 		} else {
 			reqwest::get(&format!("{}/{}/{}", QUOTATION_ENDPOINT, asset.blockchain, asset.address))

--- a/dia-batching-server/src/dia.rs
+++ b/dia-batching-server/src/dia.rs
@@ -49,7 +49,9 @@ pub struct Asset {
 	pub blockchain: String,
 }
 
+/// Find information on how to use it here: https://docs.diadata.org/documentation/api-1/traditional-finance-data-api-endpoints
 const FOREIGN_QUOTATION_ENDPOINT: &str = "https://api.diadata.org/v1/foreignQuotation/YahooFinance";
+
 const QUOTATION_ENDPOINT: &str = "https://api.diadata.org/v1/assetQuotation";
 /// ### Quotation
 ///
@@ -155,8 +157,7 @@ impl DiaApi for Dia {
 		let r = if asset.blockchain.to_uppercase() == "FIAT" {
 			// The fiat symbol should be of form `{base}-{target}` (e.g. "MXN-USD") for the API to work
 			let fiat_symbol = asset.symbol.to_uppercase();
-			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_symbol))
-				.await?
+			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_symbol)).await?
 		} else {
 			reqwest::get(&format!("{}/{}/{}", QUOTATION_ENDPOINT, asset.blockchain, asset.address))
 				.await?

--- a/dia-batching-server/src/dia.rs
+++ b/dia-batching-server/src/dia.rs
@@ -156,7 +156,7 @@ impl DiaApi for Dia {
 			// We assume here that our base currency will always be USD
 			const TARGET_CURRENCY: &str = "USD";
 			// Note that the order is important here. We want the 'fiat to USD' price
-			let fiat_quote = &format!("{}/{}", asset.symbol, TARGET_CURRENCY);
+			let fiat_quote = &format!("{}-{}", asset.symbol, TARGET_CURRENCY);
 			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_quote))
 				.await?
 		} else {

--- a/dia-batching-server/src/dia.rs
+++ b/dia-batching-server/src/dia.rs
@@ -154,8 +154,9 @@ impl DiaApi for Dia {
 
 		let r = if asset.blockchain == "FIAT" {
 			// We assume here that our base currency will always be USD
-			const BASE_CURRENCY: &str = "USD";
-			let fiat_quote = &format!("{}/{}", BASE_CURRENCY, asset.symbol);
+			const TARGET_CURRENCY: &str = "USD";
+			// Note that the order is important here. We want the 'fiat to USD' price
+			let fiat_quote = &format!("{}/{}", asset.symbol, TARGET_CURRENCY);
 			reqwest::get(&format!("{}/{}", FOREIGN_QUOTATION_ENDPOINT, fiat_quote))
 				.await?
 		} else {

--- a/dia-batching-server/src/main.rs
+++ b/dia-batching-server/src/main.rs
@@ -25,8 +25,6 @@ pub struct AssetSpecifier {
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 	pretty_env_logger::init();
 
-	println!("Starting dia-batching-server...");
-
 	let args: DiaApiArgs = DiaApiArgs::from_args();
 	let storage = Arc::new(CoinInfoStorage::default());
 	let data = web::Data::from(storage.clone());
@@ -38,7 +36,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 		supported_currencies_vec.filter(|x| x.len() > 0).map(|curs| {
 			curs.into_iter()
 				.filter_map(|asset| {
-					println!("Asset: {}", asset);
 					let (blockchain, symbol) = asset.trim().split_once(":").or_else(|| {
 						error!("Invalid asset '{}' – every asset needs to have the form <blockchain>:<symbol>", asset);
 						None
@@ -59,7 +56,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 		.bind("0.0.0.0:8070")?
 		.run()
 		.await?;
-
 
 	Ok(())
 }

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -1,4 +1,4 @@
-use crate::dia::{DiaApi, Quotation};
+use crate::dia::{Asset, DiaApi, Quotation, QuotedAsset};
 use crate::storage::{CoinInfo, CoinInfoStorage};
 use crate::AssetSpecifier;
 use log::{error, info};
@@ -9,374 +9,443 @@ use std::fmt::{Display, Formatter};
 use std::{error::Error, sync::Arc};
 
 pub async fn run_update_prices_loop<T>(
-	storage: Arc<CoinInfoStorage>,
-	maybe_supported_currencies: Option<HashSet<AssetSpecifier>>,
-	rate: std::time::Duration,
-	duration: std::time::Duration,
-	api: T,
+    storage: Arc<CoinInfoStorage>,
+    maybe_supported_currencies: Option<HashSet<AssetSpecifier>>,
+    rate: std::time::Duration,
+    duration: std::time::Duration,
+    api: T,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
-where
-	T: DiaApi + Send + Sync + 'static,
+    where
+        T: DiaApi + Send + Sync + 'static,
 {
-	let coins = Arc::clone(&storage);
-	let _ = tokio::spawn(async move {
-		loop {
-			let time_elapsed = std::time::Instant::now();
+    let coins = Arc::clone(&storage);
+    let _ = tokio::spawn(async move {
+        loop {
+            let time_elapsed = std::time::Instant::now();
 
-			let coins = Arc::clone(&coins);
+            let coins = Arc::clone(&coins);
 
-			update_prices(coins, &maybe_supported_currencies, &api, rate).await;
+            update_prices(coins, &maybe_supported_currencies, &api, rate).await;
 
-			tokio::time::delay_for(duration.saturating_sub(time_elapsed.elapsed())).await;
-		}
-	});
+            tokio::time::delay_for(duration.saturating_sub(time_elapsed.elapsed())).await;
+        }
+    });
 
-	Ok(())
+    Ok(())
 }
 
 fn convert_to_coin_info(value: Quotation) -> Result<CoinInfo, Box<dyn Error + Sync + Send>> {
-	let Quotation { name, symbol, blockchain, price, time, volume_yesterday, .. } = value;
+    let Quotation { name, symbol, blockchain, price, time, volume_yesterday, .. } = value;
 
-	let price = convert_decimal_to_u128(&price)?;
-	let supply = convert_decimal_to_u128(&volume_yesterday)?;
+    let price = convert_decimal_to_u128(&price)?;
+    let supply = convert_decimal_to_u128(&volume_yesterday)?;
 
-	let coin_info = CoinInfo {
-		name: name.into(),
-		symbol: symbol.into(),
-		blockchain: blockchain.into(),
-		price,
-		last_update_timestamp: time.timestamp().unsigned_abs(),
-		supply,
-	};
+    let coin_info = CoinInfo {
+        name: name.into(),
+        symbol: symbol.into(),
+        blockchain: blockchain.unwrap_or("FIAT".to_string()).into(),
+        price,
+        last_update_timestamp: time.timestamp().unsigned_abs(),
+        supply,
+    };
 
-	info!("Coin Price: {:#?}", price);
-	info!("Coin Supply: {:#?}", volume_yesterday);
-	info!("Coin Info : {:#?}", coin_info);
+    info!("Coin Price: {:#?}", price);
+    info!("Coin Supply: {:#?}", volume_yesterday);
+    info!("Coin Info : {:#?}", coin_info);
 
-	Ok(coin_info)
+    Ok(coin_info)
 }
 
 async fn update_prices<T>(
-	coins: Arc<CoinInfoStorage>,
-	maybe_supported_currencies: &Option<HashSet<AssetSpecifier>>,
-	api: &T,
-	rate: std::time::Duration,
+    coins: Arc<CoinInfoStorage>,
+    maybe_supported_currencies: &Option<HashSet<AssetSpecifier>>,
+    api: &T,
+    rate: std::time::Duration,
 ) where
-	T: DiaApi + Send + Sync + 'static,
+    T: DiaApi + Send + Sync + 'static,
 {
-	if let Ok(quotable_assets) = api.get_quotable_assets().await {
-		info!("No. of quotable assets to retrieve : {}", quotable_assets.len());
+    let mut currencies = vec![];
 
-		let mut currencies = vec![];
+    if let Ok(quotable_assets) = api.get_quotable_assets().await {
+        info!("No. of quotable assets to retrieve : {}", quotable_assets.len());
 
-		for quotable_asset in quotable_assets {
-			let asset = AssetSpecifier {
-				blockchain: quotable_asset.asset.blockchain.clone(),
-				symbol: quotable_asset.asset.symbol.clone(),
-			};
 
-			if maybe_supported_currencies
-				.as_ref()
-				.map_or(true, |supported| supported.contains(&asset))
-			{
-				match api.get_quotation(&quotable_asset).await.and_then(convert_to_coin_info) {
-					Ok(coin_info) => {
-						currencies.push(coin_info);
-					},
-					Err(err) => {
-						error!("Error while retrieving quotation for {:?}: {}", quotable_asset, err)
-					},
-				}
-				tokio::time::delay_for(rate).await;
-			}
-		}
+        for quotable_asset in quotable_assets {
+            let asset = AssetSpecifier {
+                blockchain: quotable_asset.asset.blockchain.clone(),
+                symbol: quotable_asset.asset.symbol.clone(),
+            };
 
-		coins.replace_currencies_by_symbols(currencies);
-		info!("Currencies Updated");
-	}
+            if maybe_supported_currencies
+                .as_ref()
+                .map_or(true, |supported| supported.contains(&asset))
+            {
+                match api.get_quotation(&quotable_asset).await.and_then(convert_to_coin_info) {
+                    Ok(coin_info) => {
+                        currencies.push(coin_info);
+                    }
+                    Err(err) => {
+                        error!("Error while retrieving quotation for {:?}: {}", quotable_asset, err)
+                    }
+                }
+                tokio::time::delay_for(rate).await;
+            }
+        }
+    }
+
+    if let Some(supported_currencies) = maybe_supported_currencies.as_ref() {
+        for asset in supported_currencies.iter() {
+            if asset.blockchain == "FIAT" {
+                // Create dummy QuotedAsset. We only need it to have the symbol and blockchain
+                let quoted_asset = QuotedAsset {
+                    asset: Asset {
+                        symbol: asset.symbol.clone(),
+                        name: "".to_string(),
+                        address: "".to_string(),
+                        decimals: 0,
+                        blockchain: asset.blockchain.clone(),
+                    },
+                    volume: Default::default(),
+                };
+                match api.get_quotation(&quoted_asset).await.and_then(convert_to_coin_info) {
+                    Ok(coin_info) => {
+                        currencies.push(coin_info);
+                    }
+                    Err(err) => {
+                        error!("Error while retrieving quotation for {:?}: {}", quoted_asset, err)
+                    }
+                }
+            }
+        };
+    }
+
+    coins.replace_currencies_by_symbols(currencies);
+    info!("Currencies Updated");
 }
+
 #[derive(Debug)]
 pub enum ConvertingError {
-	DecimalTooLarge,
+    DecimalTooLarge,
 }
 
 impl Display for ConvertingError {
-	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-		match self {
-			ConvertingError::DecimalTooLarge => write!(f, "Decimal given is too large"),
-		}
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConvertingError::DecimalTooLarge => write!(f, "Decimal given is too large"),
+        }
+    }
 }
 
 impl Error for ConvertingError {}
 
 fn convert_decimal_to_u128(input: &Decimal) -> Result<u128, ConvertingError> {
-	let fract = (input.fract() * Decimal::from(1_000_000_000_000_u128))
-		.to_u128()
-		.ok_or(ConvertingError::DecimalTooLarge)?;
-	let trunc = (input.trunc() * Decimal::from(1_000_000_000_000_u128))
-		.to_u128()
-		.ok_or(ConvertingError::DecimalTooLarge)?;
+    let fract = (input.fract() * Decimal::from(1_000_000_000_000_u128))
+        .to_u128()
+        .ok_or(ConvertingError::DecimalTooLarge)?;
+    let trunc = (input.trunc() * Decimal::from(1_000_000_000_000_u128))
+        .to_u128()
+        .ok_or(ConvertingError::DecimalTooLarge)?;
 
-	Ok(trunc.saturating_add(fract))
+    Ok(trunc.saturating_add(fract))
 }
 
 #[cfg(test)]
 mod tests {
-	use crate::{
-		dia::{Asset, QuotedAsset},
-		handlers::Currency,
-	};
-	use std::{collections::HashMap, error::Error, sync::Arc};
+    use crate::{
+        dia::{Asset, QuotedAsset},
+        handlers::Currency,
+    };
+    use std::{collections::HashMap, error::Error, sync::Arc};
 
-	use async_trait::async_trait;
-	use chrono::Utc;
-	use rust_decimal_macros::dec;
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use rust_decimal_macros::dec;
 
-	use super::*;
+    use super::*;
 
-	struct MockDia {
-		quotation: HashMap<AssetSpecifier, Quotation>,
-	}
+    struct MockDia {
+        quotation: HashMap<AssetSpecifier, Quotation>,
+    }
 
-	impl MockDia {
-		pub fn new() -> Self {
-			let mut quotation = HashMap::new();
-			quotation.insert(
-				AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-				Quotation {
-					name: "BTC".into(),
-					price: dec!(1.000000000000),
-					price_yesterday: dec!(1.000000000000),
-					symbol: "BTC".into(),
-					time: Utc::now(),
-					volume_yesterday: dec!(0.123456789012345),
-					address: "0x0000000000000000000000000000000000000000".into(),
-					blockchain: "Bitcoin".into(),
-					source: "diadata.org".into(),
-				},
-			);
-			quotation.insert(
-				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "ETH".into() },
-				Quotation {
-					name: "ETH".into(),
-					price: dec!(1.000000000000),
-					price_yesterday: dec!(1.000000000000),
-					symbol: "ETH".into(),
-					time: Utc::now(),
-					volume_yesterday: dec!(298134760),
-					address: "0x0000000000000000000000000000000000000000".into(),
-					blockchain: "Ethereum".into(),
-					source: "diadata.org".into(),
-				},
-			);
-			quotation.insert(
-				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-				Quotation {
-					name: "USDT".into(),
-					price: dec!(1.000000000001),
-					price_yesterday: dec!(1.000000000000),
-					symbol: "USDT".into(),
-					time: Utc::now(),
-					volume_yesterday: dec!(0.000000000001),
-					address: "0x0000000000000000000000000000000000000000".into(),
-					blockchain: "Ethereum".into(),
-					source: "diadata.org".into(),
-				},
-			);
-			quotation.insert(
-				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-				Quotation {
-					name: "USDC".into(),
-					price: dec!(123456789.123456789012345),
-					price_yesterday: dec!(1.000000000000),
-					symbol: "USDC".into(),
-					time: Utc::now(),
-					volume_yesterday: dec!(298134760),
-					address: "0x0000000000000000000000000000000000000000".into(),
-					blockchain: "Ethereum".into(),
-					source: "diadata.org".into(),
-				},
-			);
-			Self { quotation }
-		}
-	}
+    impl MockDia {
+        pub fn new() -> Self {
+            let mut quotation = HashMap::new();
+            quotation.insert(
+                AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+                Quotation {
+                    name: "BTC".into(),
+                    price: dec!(1.000000000000),
+                    price_yesterday: dec!(1.000000000000),
+                    symbol: "BTC".into(),
+                    time: Utc::now(),
+                    volume_yesterday: dec!(0.123456789012345),
+                    address: Some("0x0000000000000000000000000000000000000000".into()),
+                    blockchain: Some("Bitcoin".into()),
+                    source: "diadata.org".into(),
+                },
+            );
+            quotation.insert(
+                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "ETH".into() },
+                Quotation {
+                    name: "ETH".into(),
+                    price: dec!(1.000000000000),
+                    price_yesterday: dec!(1.000000000000),
+                    symbol: "ETH".into(),
+                    time: Utc::now(),
+                    volume_yesterday: dec!(298134760),
+                    address: Some("0x0000000000000000000000000000000000000000".into()),
+                    blockchain: Some("Ethereum".into()),
+                    source: "diadata.org".into(),
+                },
+            );
+            quotation.insert(
+                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+                Quotation {
+                    name: "USDT".into(),
+                    price: dec!(1.000000000001),
+                    price_yesterday: dec!(1.000000000000),
+                    symbol: "USDT".into(),
+                    time: Utc::now(),
+                    volume_yesterday: dec!(0.000000000001),
+                    address: Some("0x0000000000000000000000000000000000000000".into()),
+                    blockchain: Some("Ethereum".into()),
+                    source: "diadata.org".into(),
+                },
+            );
+            quotation.insert(
+                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+                Quotation {
+                    name: "USDC".into(),
+                    price: dec!(123456789.123456789012345),
+                    price_yesterday: dec!(1.000000000000),
+                    symbol: "USDC".into(),
+                    time: Utc::now(),
+                    volume_yesterday: dec!(298134760),
+                    address: Some("0x0000000000000000000000000000000000000000".into()),
+                    blockchain: Some("Ethereum".into()),
+                    source: "diadata.org".into(),
+                },
+            );
+            quotation.insert(
+                AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN".into() },
+                Quotation {
+                    name: "MXN-X".into(),
+                    price: dec!(18.65192),
+                    price_yesterday: dec!(18.550382926829265),
+                    symbol: "USD-MXN".into(),
+                    time: Utc::now(),
+                    volume_yesterday: dec!(0),
+                    address: None,
+                    blockchain: None,
+                    source: "YahooFinance".into(),
+                }
+            );
+            Self { quotation }
+        }
+    }
 
-	#[async_trait]
-	impl DiaApi for MockDia {
-		async fn get_quotation(
-			&self,
-			asset: &QuotedAsset,
-		) -> Result<Quotation, Box<dyn Error + Send + Sync>> {
-			let QuotedAsset { asset, volume: _ } = asset;
-			let asset = AssetSpecifier {
-				blockchain: asset.blockchain.clone(),
-				symbol: asset.symbol.clone(),
-			};
-			Ok(self.quotation.get(&asset).ok_or("Error Finding Quotation".to_string())?.clone())
-		}
+    #[async_trait]
+    impl DiaApi for MockDia {
+        async fn get_quotation(
+            &self,
+            asset: &QuotedAsset,
+        ) -> Result<Quotation, Box<dyn Error + Send + Sync>> {
+            let QuotedAsset { asset, volume: _ } = asset;
+            let asset = AssetSpecifier {
+                blockchain: asset.blockchain.clone(),
+                symbol: asset.symbol.clone(),
+            };
+            let quotation = self.quotation.get(&asset).ok_or("Error Finding Quotation".to_string())?;
+            Ok(quotation.clone())
+        }
 
-		async fn get_quotable_assets(
-			&self,
-		) -> Result<Vec<QuotedAsset>, Box<dyn Error + Send + Sync>> {
-			Ok(vec![
-				QuotedAsset {
-					asset: Asset {
-						symbol: "BTC".into(),
-						name: "Bitcoin".into(),
-						address: "0x0000000000000000000000000000000000000000".into(),
-						decimals: 8,
-						blockchain: "Bitcoin".into(),
-					},
-					volume: Decimal::new(3818975389095178, 6),
-				},
-				QuotedAsset {
-					asset: Asset {
-						symbol: "ETH".into(),
-						name: "Ether".into(),
-						address: "0x0000000000000000000000000000000000000000".into(),
-						decimals: 18,
-						blockchain: "Ethereum".into(),
-					},
-					volume: Decimal::new(791232743889491, 6),
-				},
-				QuotedAsset {
-					asset: Asset {
-						symbol: "USDT".into(),
-						name: "Tether USD".into(),
-						address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
-						decimals: 6,
-						blockchain: "Ethereum".into(),
-					},
-					volume: Decimal::new(294107237463418, 6),
-				},
-				QuotedAsset {
-					asset: Asset {
-						symbol: "USDC".into(),
-						name: "USD Coin".into(),
-						address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".into(),
-						decimals: 6,
-						blockchain: "Ethereum".into(),
-					},
-					volume: Decimal::new(205584209531937, 6),
-				},
-			])
-		}
-	}
-	#[tokio::test]
-	async fn test_update_prices() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+        async fn get_quotable_assets(
+            &self,
+        ) -> Result<Vec<QuotedAsset>, Box<dyn Error + Send + Sync>> {
+            Ok(vec![
+                QuotedAsset {
+                    asset: Asset {
+                        symbol: "BTC".into(),
+                        name: "Bitcoin".into(),
+                        address: "0x0000000000000000000000000000000000000000".into(),
+                        decimals: 8,
+                        blockchain: "Bitcoin".into(),
+                    },
+                    volume: Decimal::new(3818975389095178, 6),
+                },
+                QuotedAsset {
+                    asset: Asset {
+                        symbol: "ETH".into(),
+                        name: "Ether".into(),
+                        address: "0x0000000000000000000000000000000000000000".into(),
+                        decimals: 18,
+                        blockchain: "Ethereum".into(),
+                    },
+                    volume: Decimal::new(791232743889491, 6),
+                },
+                QuotedAsset {
+                    asset: Asset {
+                        symbol: "USDT".into(),
+                        name: "Tether USD".into(),
+                        address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
+                        decimals: 6,
+                        blockchain: "Ethereum".into(),
+                    },
+                    volume: Decimal::new(294107237463418, 6),
+                },
+                QuotedAsset {
+                    asset: Asset {
+                        symbol: "USDC".into(),
+                        name: "USD Coin".into(),
+                        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".into(),
+                        decimals: 6,
+                        blockchain: "Ethereum".into(),
+                    },
+                    volume: Decimal::new(205584209531937, 6),
+                },
+            ])
+        }
+    }
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "ETH".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-		]);
+    #[tokio::test]
+    async fn test_update_prices() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		assert_eq!(4, c.len());
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "ETH".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+        ]);
 
-		assert_eq!(c[1].price, 1000000000000);
+        assert_eq!(4, c.len());
 
-		assert_eq!(c[1].name, "ETH");
-	}
+        assert_eq!(c[1].price, 1000000000000);
 
-	#[tokio::test]
-	async fn test_update_prices_non_existent() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+        assert_eq!(c[1].name, "ETH");
+    }
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-			Currency { blockchain: "Bitcoin".into(), symbol: "BTCCash".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
-		]);
+    #[tokio::test]
+    async fn test_update_prices_with_fiat() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
 
-		assert_eq!(0, c.len());
-	}
+        let mut all_currencies = HashSet::new();
+        all_currencies.insert(AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() });
+        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN".into() });
+        let all_currencies = Some(all_currencies);
 
-	#[tokio::test]
-	async fn test_update_prices_one_available() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
-		]);
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+            Currency { blockchain: "FIAT".into(), symbol: "USD-MXN".into() },
+        ]);
 
-		assert_eq!(1, c.len());
+        assert_eq!(2, c.len());
 
-		assert_eq!(c[0].price, 1000000000000);
+        assert_eq!(c[1].price, 18651920000000);
 
-		assert_eq!(c[0].name, "BTC");
-	}
+        assert_eq!(c[1].name, "MXN-X");
+    }
 
-	#[tokio::test]
-	async fn test_update_prices_get_nothing() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+    #[tokio::test]
+    async fn test_update_prices_non_existent() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![]);
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "Bitcoin".into(), symbol: "BTCCash".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
+        ]);
 
-		assert_eq!(0, c.len());
-	}
+        assert_eq!(0, c.len());
+    }
 
-	#[tokio::test]
-	async fn test_update_prices_get_integers() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
+    #[tokio::test]
+    async fn test_update_prices_one_available() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
+        ]);
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![Currency {
-			blockchain: "Bitcoin".into(),
-			symbol: "123".into(),
-		}]);
+        assert_eq!(1, c.len());
 
-		assert_eq!(0, c.len());
-	}
+        assert_eq!(c[0].price, 1000000000000);
 
-	#[tokio::test]
-	async fn test_convert_result() {
-		let mock_api = MockDia::new();
-		let storage = Arc::new(CoinInfoStorage::default());
-		let coins = Arc::clone(&storage);
-		let all_currencies = None;
+        assert_eq!(c[0].name, "BTC");
+    }
 
-		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+    #[tokio::test]
+    async fn test_update_prices_get_nothing() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-			Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-		]);
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![]);
 
-		assert_eq!(c[0].price, 1000000000000);
-		assert_eq!(c[0].supply, 123456789012);
+        assert_eq!(0, c.len());
+    }
 
-		assert_eq!(c[1].price, 123456789123456789012);
-		assert_eq!(c[1].supply, 298134760000000000000);
+    #[tokio::test]
+    async fn test_update_prices_get_integers() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
 
-		assert_eq!(c[2].price, 1000000000001);
-		assert_eq!(c[2].supply, 1);
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-		assert_eq!(c[0].name, "BTC");
-		assert_eq!(c[1].name, "USDC");
-		assert_eq!(c[2].name, "USDT");
-	}
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![Currency {
+            blockchain: "Bitcoin".into(),
+            symbol: "123".into(),
+        }]);
+
+        assert_eq!(0, c.len());
+    }
+
+    #[tokio::test]
+    async fn test_convert_result() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+        let all_currencies = None;
+
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+            Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+        ]);
+
+        assert_eq!(c[0].price, 1000000000000);
+        assert_eq!(c[0].supply, 123456789012);
+
+        assert_eq!(c[1].price, 123456789123456789012);
+        assert_eq!(c[1].supply, 298134760000000000000);
+
+        assert_eq!(c[2].price, 1000000000001);
+        assert_eq!(c[2].supply, 1);
+
+        assert_eq!(c[0].name, "BTC");
+        assert_eq!(c[1].name, "USDC");
+        assert_eq!(c[2].name, "USDT");
+    }
 }

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -229,10 +229,10 @@ mod tests {
             quotation.insert(
                 AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN".into() },
                 Quotation {
-                    name: "MXN-X".into(),
-                    price: dec!(18.65192),
-                    price_yesterday: dec!(18.550382926829265),
-                    symbol: "USD-MXN".into(),
+                    name: "MXNUSD=X".into(),
+                    price: dec!(0.053712327),
+                    price_yesterday: dec!(0.053910317166666666),
+                    symbol: "MXN-USD".into(),
                     time: Utc::now(),
                     volume_yesterday: dec!(0),
                     address: None,
@@ -348,14 +348,14 @@ mod tests {
 
         let c = storage.get_currencies_by_blockchains_and_symbols(vec![
             Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-            Currency { blockchain: "FIAT".into(), symbol: "USD-MXN".into() },
+            Currency { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
         ]);
 
         assert_eq!(2, c.len());
 
-        assert_eq!(c[1].price, 18651920000000);
+        assert_eq!(c[1].price, 53712327000);
 
-        assert_eq!(c[1].name, "MXN-X");
+        assert_eq!(c[1].name, "MXNUSD=X");
     }
 
     #[tokio::test]

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -227,7 +227,7 @@ mod tests {
                 },
             );
             quotation.insert(
-                AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN".into() },
+                AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
                 Quotation {
                     name: "MXNUSD=X".into(),
                     price: dec!(0.053712327),
@@ -241,7 +241,7 @@ mod tests {
                 }
             );
             quotation.insert(
-                AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD".into() },
+                AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() },
                 Quotation::get_default_fiat_usd_quotation(),
             );
             Self { quotation }
@@ -341,7 +341,7 @@ mod tests {
 
         let mut all_currencies = HashSet::new();
         all_currencies.insert(AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() });
-        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN".into() });
+        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() });
         let all_currencies = Some(all_currencies);
 
         update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
@@ -365,7 +365,7 @@ mod tests {
         let coins = Arc::clone(&storage);
 
         let mut all_currencies = HashSet::new();
-        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD".into() });
+        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() });
         let all_currencies = Some(all_currencies);
 
         update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -240,6 +240,10 @@ mod tests {
                     source: "YahooFinance".into(),
                 }
             );
+            quotation.insert(
+                AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD".into() },
+                Quotation::get_default_fiat_usd_quotation(),
+            );
             Self { quotation }
         }
     }
@@ -330,7 +334,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_prices_with_fiat() {
+    async fn test_update_prices_with_fiat_and_crypto_asset_works() {
         let mock_api = MockDia::new();
         let storage = Arc::new(CoinInfoStorage::default());
         let coins = Arc::clone(&storage);
@@ -352,6 +356,29 @@ mod tests {
         assert_eq!(c[1].price, 18651920000000);
 
         assert_eq!(c[1].name, "MXN-X");
+    }
+
+    #[tokio::test]
+    async fn test_update_prices_with_fiat_usd_works() {
+        let mock_api = MockDia::new();
+        let storage = Arc::new(CoinInfoStorage::default());
+        let coins = Arc::clone(&storage);
+
+        let mut all_currencies = HashSet::new();
+        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD".into() });
+        let all_currencies = Some(all_currencies);
+
+        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+
+        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+            Currency { blockchain: "FIAT".into(), symbol: "USD-USD".into() },
+        ]);
+
+        assert_eq!(1, c.len());
+
+        assert_eq!(c[0].price, 1000000000000);
+
+        assert_eq!(c[0].name, "USD-X");
     }
 
     #[tokio::test]

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -9,470 +9,474 @@ use std::fmt::{Display, Formatter};
 use std::{error::Error, sync::Arc};
 
 pub async fn run_update_prices_loop<T>(
-    storage: Arc<CoinInfoStorage>,
-    maybe_supported_currencies: Option<HashSet<AssetSpecifier>>,
-    rate: std::time::Duration,
-    duration: std::time::Duration,
-    api: T,
+	storage: Arc<CoinInfoStorage>,
+	maybe_supported_currencies: Option<HashSet<AssetSpecifier>>,
+	rate: std::time::Duration,
+	duration: std::time::Duration,
+	api: T,
 ) -> Result<(), Box<dyn Error + Send + Sync + 'static>>
-    where
-        T: DiaApi + Send + Sync + 'static,
+where
+	T: DiaApi + Send + Sync + 'static,
 {
-    let coins = Arc::clone(&storage);
-    let _ = tokio::spawn(async move {
-        loop {
-            let time_elapsed = std::time::Instant::now();
+	let coins = Arc::clone(&storage);
+	let _ = tokio::spawn(async move {
+		loop {
+			let time_elapsed = std::time::Instant::now();
 
-            let coins = Arc::clone(&coins);
+			let coins = Arc::clone(&coins);
 
-            update_prices(coins, &maybe_supported_currencies, &api, rate).await;
+			update_prices(coins, &maybe_supported_currencies, &api, rate).await;
 
-            tokio::time::delay_for(duration.saturating_sub(time_elapsed.elapsed())).await;
-        }
-    });
+			tokio::time::delay_for(duration.saturating_sub(time_elapsed.elapsed())).await;
+		}
+	});
 
-    Ok(())
+	Ok(())
 }
 
 fn convert_to_coin_info(value: Quotation) -> Result<CoinInfo, Box<dyn Error + Sync + Send>> {
-    let Quotation { name, symbol, blockchain, price, time, volume_yesterday, .. } = value;
+	let Quotation { name, symbol, blockchain, price, time, volume_yesterday, .. } = value;
 
-    let price = convert_decimal_to_u128(&price)?;
-    let supply = convert_decimal_to_u128(&volume_yesterday)?;
+	let price = convert_decimal_to_u128(&price)?;
+	let supply = convert_decimal_to_u128(&volume_yesterday)?;
 
-    let coin_info = CoinInfo {
-        name: name.into(),
-        symbol: symbol.into(),
-        blockchain: blockchain.unwrap_or("FIAT".to_string()).into(),
-        price,
-        last_update_timestamp: time.timestamp().unsigned_abs(),
-        supply,
-    };
+	let coin_info = CoinInfo {
+		name: name.into(),
+		symbol: symbol.into(),
+		blockchain: blockchain.unwrap_or("FIAT".to_string()).into(),
+		price,
+		last_update_timestamp: time.timestamp().unsigned_abs(),
+		supply,
+	};
 
-    info!("Coin Price: {:#?}", price);
-    info!("Coin Supply: {:#?}", volume_yesterday);
-    info!("Coin Info : {:#?}", coin_info);
+	info!("Coin Price: {:#?}", price);
+	info!("Coin Supply: {:#?}", volume_yesterday);
+	info!("Coin Info : {:#?}", coin_info);
 
-    Ok(coin_info)
+	Ok(coin_info)
 }
 
 async fn update_prices<T>(
-    coins: Arc<CoinInfoStorage>,
-    maybe_supported_currencies: &Option<HashSet<AssetSpecifier>>,
-    api: &T,
-    rate: std::time::Duration,
+	coins: Arc<CoinInfoStorage>,
+	maybe_supported_currencies: &Option<HashSet<AssetSpecifier>>,
+	api: &T,
+	rate: std::time::Duration,
 ) where
-    T: DiaApi + Send + Sync + 'static,
+	T: DiaApi + Send + Sync + 'static,
 {
-    let mut currencies = vec![];
+	let mut currencies = vec![];
 
-    if let Ok(quotable_assets) = api.get_quotable_assets().await {
-        info!("No. of quotable assets to retrieve : {}", quotable_assets.len());
+	if let Ok(quotable_assets) = api.get_quotable_assets().await {
+		info!("No. of quotable assets to retrieve : {}", quotable_assets.len());
 
+		for quotable_asset in quotable_assets {
+			let asset = AssetSpecifier {
+				blockchain: quotable_asset.asset.blockchain.clone(),
+				symbol: quotable_asset.asset.symbol.clone(),
+			};
 
-        for quotable_asset in quotable_assets {
-            let asset = AssetSpecifier {
-                blockchain: quotable_asset.asset.blockchain.clone(),
-                symbol: quotable_asset.asset.symbol.clone(),
-            };
+			if maybe_supported_currencies
+				.as_ref()
+				.map_or(true, |supported| supported.contains(&asset))
+			{
+				match api.get_quotation(&quotable_asset).await.and_then(convert_to_coin_info) {
+					Ok(coin_info) => {
+						currencies.push(coin_info);
+					},
+					Err(err) => {
+						error!("Error while retrieving quotation for {:?}: {}", quotable_asset, err)
+					},
+				}
+				tokio::time::delay_for(rate).await;
+			}
+		}
+	}
 
-            if maybe_supported_currencies
-                .as_ref()
-                .map_or(true, |supported| supported.contains(&asset))
-            {
-                match api.get_quotation(&quotable_asset).await.and_then(convert_to_coin_info) {
-                    Ok(coin_info) => {
-                        currencies.push(coin_info);
-                    }
-                    Err(err) => {
-                        error!("Error while retrieving quotation for {:?}: {}", quotable_asset, err)
-                    }
-                }
-                tokio::time::delay_for(rate).await;
-            }
-        }
-    }
+	if let Some(supported_currencies) = maybe_supported_currencies.as_ref() {
+		for asset in supported_currencies.iter() {
+			if asset.blockchain == "FIAT" {
+				// Create dummy QuotedAsset. We only need it to have the symbol and blockchain
+				let quoted_asset = QuotedAsset {
+					asset: Asset {
+						symbol: asset.symbol.clone(),
+						name: "".to_string(),
+						address: "".to_string(),
+						decimals: 0,
+						blockchain: asset.blockchain.clone(),
+					},
+					volume: Default::default(),
+				};
+				match api.get_quotation(&quoted_asset).await.and_then(convert_to_coin_info) {
+					Ok(coin_info) => {
+						currencies.push(coin_info);
+					},
+					Err(err) => {
+						error!("Error while retrieving quotation for {:?}: {}", quoted_asset, err)
+					},
+				}
+			}
+		}
+	}
 
-    if let Some(supported_currencies) = maybe_supported_currencies.as_ref() {
-        for asset in supported_currencies.iter() {
-            if asset.blockchain == "FIAT" {
-                // Create dummy QuotedAsset. We only need it to have the symbol and blockchain
-                let quoted_asset = QuotedAsset {
-                    asset: Asset {
-                        symbol: asset.symbol.clone(),
-                        name: "".to_string(),
-                        address: "".to_string(),
-                        decimals: 0,
-                        blockchain: asset.blockchain.clone(),
-                    },
-                    volume: Default::default(),
-                };
-                match api.get_quotation(&quoted_asset).await.and_then(convert_to_coin_info) {
-                    Ok(coin_info) => {
-                        currencies.push(coin_info);
-                    }
-                    Err(err) => {
-                        error!("Error while retrieving quotation for {:?}: {}", quoted_asset, err)
-                    }
-                }
-            }
-        };
-    }
-
-    coins.replace_currencies_by_symbols(currencies);
-    info!("Currencies Updated");
+	coins.replace_currencies_by_symbols(currencies);
+	info!("Currencies Updated");
 }
 
 #[derive(Debug)]
 pub enum ConvertingError {
-    DecimalTooLarge,
+	DecimalTooLarge,
 }
 
 impl Display for ConvertingError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ConvertingError::DecimalTooLarge => write!(f, "Decimal given is too large"),
-        }
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			ConvertingError::DecimalTooLarge => write!(f, "Decimal given is too large"),
+		}
+	}
 }
 
 impl Error for ConvertingError {}
 
 fn convert_decimal_to_u128(input: &Decimal) -> Result<u128, ConvertingError> {
-    let fract = (input.fract() * Decimal::from(1_000_000_000_000_u128))
-        .to_u128()
-        .ok_or(ConvertingError::DecimalTooLarge)?;
-    let trunc = (input.trunc() * Decimal::from(1_000_000_000_000_u128))
-        .to_u128()
-        .ok_or(ConvertingError::DecimalTooLarge)?;
+	let fract = (input.fract() * Decimal::from(1_000_000_000_000_u128))
+		.to_u128()
+		.ok_or(ConvertingError::DecimalTooLarge)?;
+	let trunc = (input.trunc() * Decimal::from(1_000_000_000_000_u128))
+		.to_u128()
+		.ok_or(ConvertingError::DecimalTooLarge)?;
 
-    Ok(trunc.saturating_add(fract))
+	Ok(trunc.saturating_add(fract))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        dia::{Asset, QuotedAsset},
-        handlers::Currency,
-    };
-    use std::{collections::HashMap, error::Error, sync::Arc};
+	use crate::{
+		dia::{Asset, QuotedAsset},
+		handlers::Currency,
+	};
+	use std::{collections::HashMap, error::Error, sync::Arc};
 
-    use async_trait::async_trait;
-    use chrono::Utc;
-    use rust_decimal_macros::dec;
+	use async_trait::async_trait;
+	use chrono::Utc;
+	use rust_decimal_macros::dec;
 
-    use super::*;
+	use super::*;
 
-    struct MockDia {
-        quotation: HashMap<AssetSpecifier, Quotation>,
-    }
+	struct MockDia {
+		quotation: HashMap<AssetSpecifier, Quotation>,
+	}
 
-    impl MockDia {
-        pub fn new() -> Self {
-            let mut quotation = HashMap::new();
-            quotation.insert(
-                AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-                Quotation {
-                    name: "BTC".into(),
-                    price: dec!(1.000000000000),
-                    price_yesterday: dec!(1.000000000000),
-                    symbol: "BTC".into(),
-                    time: Utc::now(),
-                    volume_yesterday: dec!(0.123456789012345),
-                    address: Some("0x0000000000000000000000000000000000000000".into()),
-                    blockchain: Some("Bitcoin".into()),
-                    source: "diadata.org".into(),
-                },
-            );
-            quotation.insert(
-                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "ETH".into() },
-                Quotation {
-                    name: "ETH".into(),
-                    price: dec!(1.000000000000),
-                    price_yesterday: dec!(1.000000000000),
-                    symbol: "ETH".into(),
-                    time: Utc::now(),
-                    volume_yesterday: dec!(298134760),
-                    address: Some("0x0000000000000000000000000000000000000000".into()),
-                    blockchain: Some("Ethereum".into()),
-                    source: "diadata.org".into(),
-                },
-            );
-            quotation.insert(
-                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-                Quotation {
-                    name: "USDT".into(),
-                    price: dec!(1.000000000001),
-                    price_yesterday: dec!(1.000000000000),
-                    symbol: "USDT".into(),
-                    time: Utc::now(),
-                    volume_yesterday: dec!(0.000000000001),
-                    address: Some("0x0000000000000000000000000000000000000000".into()),
-                    blockchain: Some("Ethereum".into()),
-                    source: "diadata.org".into(),
-                },
-            );
-            quotation.insert(
-                AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-                Quotation {
-                    name: "USDC".into(),
-                    price: dec!(123456789.123456789012345),
-                    price_yesterday: dec!(1.000000000000),
-                    symbol: "USDC".into(),
-                    time: Utc::now(),
-                    volume_yesterday: dec!(298134760),
-                    address: Some("0x0000000000000000000000000000000000000000".into()),
-                    blockchain: Some("Ethereum".into()),
-                    source: "diadata.org".into(),
-                },
-            );
-            quotation.insert(
-                AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
-                Quotation {
-                    name: "MXNUSD=X".into(),
-                    price: dec!(0.053712327),
-                    price_yesterday: dec!(0.053910317166666666),
-                    symbol: "MXN-USD".into(),
-                    time: Utc::now(),
-                    volume_yesterday: dec!(0),
-                    address: None,
-                    blockchain: None,
-                    source: "YahooFinance".into(),
-                }
-            );
-            quotation.insert(
-                AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() },
-                Quotation::get_default_fiat_usd_quotation(),
-            );
-            Self { quotation }
-        }
-    }
+	impl MockDia {
+		pub fn new() -> Self {
+			let mut quotation = HashMap::new();
+			quotation.insert(
+				AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+				Quotation {
+					name: "BTC".into(),
+					price: dec!(1.000000000000),
+					price_yesterday: dec!(1.000000000000),
+					symbol: "BTC".into(),
+					time: Utc::now(),
+					volume_yesterday: dec!(0.123456789012345),
+					address: Some("0x0000000000000000000000000000000000000000".into()),
+					blockchain: Some("Bitcoin".into()),
+					source: "diadata.org".into(),
+				},
+			);
+			quotation.insert(
+				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "ETH".into() },
+				Quotation {
+					name: "ETH".into(),
+					price: dec!(1.000000000000),
+					price_yesterday: dec!(1.000000000000),
+					symbol: "ETH".into(),
+					time: Utc::now(),
+					volume_yesterday: dec!(298134760),
+					address: Some("0x0000000000000000000000000000000000000000".into()),
+					blockchain: Some("Ethereum".into()),
+					source: "diadata.org".into(),
+				},
+			);
+			quotation.insert(
+				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+				Quotation {
+					name: "USDT".into(),
+					price: dec!(1.000000000001),
+					price_yesterday: dec!(1.000000000000),
+					symbol: "USDT".into(),
+					time: Utc::now(),
+					volume_yesterday: dec!(0.000000000001),
+					address: Some("0x0000000000000000000000000000000000000000".into()),
+					blockchain: Some("Ethereum".into()),
+					source: "diadata.org".into(),
+				},
+			);
+			quotation.insert(
+				AssetSpecifier { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+				Quotation {
+					name: "USDC".into(),
+					price: dec!(123456789.123456789012345),
+					price_yesterday: dec!(1.000000000000),
+					symbol: "USDC".into(),
+					time: Utc::now(),
+					volume_yesterday: dec!(298134760),
+					address: Some("0x0000000000000000000000000000000000000000".into()),
+					blockchain: Some("Ethereum".into()),
+					source: "diadata.org".into(),
+				},
+			);
+			quotation.insert(
+				AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
+				Quotation {
+					name: "MXNUSD=X".into(),
+					price: dec!(0.053712327),
+					price_yesterday: dec!(0.053910317166666666),
+					symbol: "MXN-USD".into(),
+					time: Utc::now(),
+					volume_yesterday: dec!(0),
+					address: None,
+					blockchain: None,
+					source: "YahooFinance".into(),
+				},
+			);
+			quotation.insert(
+				AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() },
+				Quotation::get_default_fiat_usd_quotation(),
+			);
+			Self { quotation }
+		}
+	}
 
-    #[async_trait]
-    impl DiaApi for MockDia {
-        async fn get_quotation(
-            &self,
-            asset: &QuotedAsset,
-        ) -> Result<Quotation, Box<dyn Error + Send + Sync>> {
-            let QuotedAsset { asset, volume: _ } = asset;
-            let asset = AssetSpecifier {
-                blockchain: asset.blockchain.clone(),
-                symbol: asset.symbol.clone(),
-            };
-            let quotation = self.quotation.get(&asset).ok_or("Error Finding Quotation".to_string())?;
-            Ok(quotation.clone())
-        }
+	#[async_trait]
+	impl DiaApi for MockDia {
+		async fn get_quotation(
+			&self,
+			asset: &QuotedAsset,
+		) -> Result<Quotation, Box<dyn Error + Send + Sync>> {
+			let QuotedAsset { asset, volume: _ } = asset;
+			let asset = AssetSpecifier {
+				blockchain: asset.blockchain.clone(),
+				symbol: asset.symbol.clone(),
+			};
+			let quotation =
+				self.quotation.get(&asset).ok_or("Error Finding Quotation".to_string())?;
+			Ok(quotation.clone())
+		}
 
-        async fn get_quotable_assets(
-            &self,
-        ) -> Result<Vec<QuotedAsset>, Box<dyn Error + Send + Sync>> {
-            Ok(vec![
-                QuotedAsset {
-                    asset: Asset {
-                        symbol: "BTC".into(),
-                        name: "Bitcoin".into(),
-                        address: "0x0000000000000000000000000000000000000000".into(),
-                        decimals: 8,
-                        blockchain: "Bitcoin".into(),
-                    },
-                    volume: Decimal::new(3818975389095178, 6),
-                },
-                QuotedAsset {
-                    asset: Asset {
-                        symbol: "ETH".into(),
-                        name: "Ether".into(),
-                        address: "0x0000000000000000000000000000000000000000".into(),
-                        decimals: 18,
-                        blockchain: "Ethereum".into(),
-                    },
-                    volume: Decimal::new(791232743889491, 6),
-                },
-                QuotedAsset {
-                    asset: Asset {
-                        symbol: "USDT".into(),
-                        name: "Tether USD".into(),
-                        address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
-                        decimals: 6,
-                        blockchain: "Ethereum".into(),
-                    },
-                    volume: Decimal::new(294107237463418, 6),
-                },
-                QuotedAsset {
-                    asset: Asset {
-                        symbol: "USDC".into(),
-                        name: "USD Coin".into(),
-                        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".into(),
-                        decimals: 6,
-                        blockchain: "Ethereum".into(),
-                    },
-                    volume: Decimal::new(205584209531937, 6),
-                },
-            ])
-        }
-    }
+		async fn get_quotable_assets(
+			&self,
+		) -> Result<Vec<QuotedAsset>, Box<dyn Error + Send + Sync>> {
+			Ok(vec![
+				QuotedAsset {
+					asset: Asset {
+						symbol: "BTC".into(),
+						name: "Bitcoin".into(),
+						address: "0x0000000000000000000000000000000000000000".into(),
+						decimals: 8,
+						blockchain: "Bitcoin".into(),
+					},
+					volume: Decimal::new(3818975389095178, 6),
+				},
+				QuotedAsset {
+					asset: Asset {
+						symbol: "ETH".into(),
+						name: "Ether".into(),
+						address: "0x0000000000000000000000000000000000000000".into(),
+						decimals: 18,
+						blockchain: "Ethereum".into(),
+					},
+					volume: Decimal::new(791232743889491, 6),
+				},
+				QuotedAsset {
+					asset: Asset {
+						symbol: "USDT".into(),
+						name: "Tether USD".into(),
+						address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".into(),
+						decimals: 6,
+						blockchain: "Ethereum".into(),
+					},
+					volume: Decimal::new(294107237463418, 6),
+				},
+				QuotedAsset {
+					asset: Asset {
+						symbol: "USDC".into(),
+						name: "USD Coin".into(),
+						address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".into(),
+						decimals: 6,
+						blockchain: "Ethereum".into(),
+					},
+					volume: Decimal::new(205584209531937, 6),
+				},
+			])
+		}
+	}
 
-    #[tokio::test]
-    async fn test_update_prices() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+	#[tokio::test]
+	async fn test_update_prices() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "ETH".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "ETH".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+		]);
 
-        assert_eq!(4, c.len());
+		assert_eq!(4, c.len());
 
-        assert_eq!(c[1].price, 1000000000000);
+		assert_eq!(c[1].price, 1000000000000);
 
-        assert_eq!(c[1].name, "ETH");
-    }
+		assert_eq!(c[1].name, "ETH");
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_with_fiat_and_crypto_asset_works() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
+	#[tokio::test]
+	async fn test_update_prices_with_fiat_and_crypto_asset_works() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
 
-        let mut all_currencies = HashSet::new();
-        all_currencies.insert(AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() });
-        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() });
-        let all_currencies = Some(all_currencies);
+		let mut all_currencies = HashSet::new();
+		all_currencies
+			.insert(AssetSpecifier { blockchain: "Bitcoin".into(), symbol: "BTC".into() });
+		all_currencies
+			.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "MXN-USD".into() });
+		let all_currencies = Some(all_currencies);
 
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-            Currency { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+			Currency { blockchain: "FIAT".into(), symbol: "MXN-USD".into() },
+		]);
 
-        assert_eq!(2, c.len());
+		assert_eq!(2, c.len());
 
-        assert_eq!(c[1].price, 53712327000);
+		assert_eq!(c[1].price, 53712327000);
 
-        assert_eq!(c[1].name, "MXNUSD=X");
-    }
+		assert_eq!(c[1].name, "MXNUSD=X");
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_with_fiat_usd_works() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
+	#[tokio::test]
+	async fn test_update_prices_with_fiat_usd_works() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
 
-        let mut all_currencies = HashSet::new();
-        all_currencies.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() });
-        let all_currencies = Some(all_currencies);
+		let mut all_currencies = HashSet::new();
+		all_currencies
+			.insert(AssetSpecifier { blockchain: "FIAT".into(), symbol: "USD-USD".into() });
+		let all_currencies = Some(all_currencies);
 
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "FIAT".into(), symbol: "USD-USD".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![Currency {
+			blockchain: "FIAT".into(),
+			symbol: "USD-USD".into(),
+		}]);
 
-        assert_eq!(1, c.len());
+		assert_eq!(1, c.len());
 
-        assert_eq!(c[0].price, 1000000000000);
+		assert_eq!(c[0].price, 1000000000000);
 
-        assert_eq!(c[0].name, "USD-X");
-    }
+		assert_eq!(c[0].name, "USD-X");
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_non_existent() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+	#[tokio::test]
+	async fn test_update_prices_non_existent() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "Bitcoin".into(), symbol: "BTCCash".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+			Currency { blockchain: "Bitcoin".into(), symbol: "BTCCash".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
+		]);
 
-        assert_eq!(0, c.len());
-    }
+		assert_eq!(0, c.len());
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_one_available() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+	#[tokio::test]
+	async fn test_update_prices_one_available() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "ETHCase".into() },
+		]);
 
-        assert_eq!(1, c.len());
+		assert_eq!(1, c.len());
 
-        assert_eq!(c[0].price, 1000000000000);
+		assert_eq!(c[0].price, 1000000000000);
 
-        assert_eq!(c[0].name, "BTC");
-    }
+		assert_eq!(c[0].name, "BTC");
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_get_nothing() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+	#[tokio::test]
+	async fn test_update_prices_get_nothing() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![]);
 
-        assert_eq!(0, c.len());
-    }
+		assert_eq!(0, c.len());
+	}
 
-    #[tokio::test]
-    async fn test_update_prices_get_integers() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
+	#[tokio::test]
+	async fn test_update_prices_get_integers() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
 
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![Currency {
-            blockchain: "Bitcoin".into(),
-            symbol: "123".into(),
-        }]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![Currency {
+			blockchain: "Bitcoin".into(),
+			symbol: "123".into(),
+		}]);
 
-        assert_eq!(0, c.len());
-    }
+		assert_eq!(0, c.len());
+	}
 
-    #[tokio::test]
-    async fn test_convert_result() {
-        let mock_api = MockDia::new();
-        let storage = Arc::new(CoinInfoStorage::default());
-        let coins = Arc::clone(&storage);
-        let all_currencies = None;
+	#[tokio::test]
+	async fn test_convert_result() {
+		let mock_api = MockDia::new();
+		let storage = Arc::new(CoinInfoStorage::default());
+		let coins = Arc::clone(&storage);
+		let all_currencies = None;
 
-        update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
+		update_prices(coins, &all_currencies, &mock_api, std::time::Duration::from_secs(1)).await;
 
-        let c = storage.get_currencies_by_blockchains_and_symbols(vec![
-            Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
-            Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
-        ]);
+		let c = storage.get_currencies_by_blockchains_and_symbols(vec![
+			Currency { blockchain: "Bitcoin".into(), symbol: "BTC".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "USDC".into() },
+			Currency { blockchain: "Ethereum".into(), symbol: "USDT".into() },
+		]);
 
-        assert_eq!(c[0].price, 1000000000000);
-        assert_eq!(c[0].supply, 123456789012);
+		assert_eq!(c[0].price, 1000000000000);
+		assert_eq!(c[0].supply, 123456789012);
 
-        assert_eq!(c[1].price, 123456789123456789012);
-        assert_eq!(c[1].supply, 298134760000000000000);
+		assert_eq!(c[1].price, 123456789123456789012);
+		assert_eq!(c[1].supply, 298134760000000000000);
 
-        assert_eq!(c[2].price, 1000000000001);
-        assert_eq!(c[2].supply, 1);
+		assert_eq!(c[2].price, 1000000000001);
+		assert_eq!(c[2].supply, 1);
 
-        assert_eq!(c[0].name, "BTC");
-        assert_eq!(c[1].name, "USDC");
-        assert_eq!(c[2].name, "USDT");
-    }
+		assert_eq!(c[0].name, "BTC");
+		assert_eq!(c[1].name, "USDC");
+		assert_eq!(c[2].name, "USDT");
+	}
 }


### PR DESCRIPTION
This PR adds support for fetching fiat prices from the DIA batching server.
It also fixes the default value parsing for the `supported_currencies` argument.

It works as follows: 
If the `blockchain` identifier of a queried currency equals `FIAT`, the batching server will request the price information from the [Traditional Finance Data API Endpoint](https://docs.diadata.org/documentation/api-1/traditional-finance-data-api-endpoints). The symbol should be of form `<base>-<target>`. For our use cases the off-chain worker in the DIA pallet should always query using `USD` as the target currency but this has to be configured in the respective runtime/chain spec of the substrate chains. I decided not to make an assumption of `USD` always being the target currency here to not make the batching server too limited to our case. The price information for `USD-USD` is handled separately because we want the offchain-worker to also feed that price to the on-chain storage. Although it does not make too much sense to query the USD to USD price, we need to have the price available on-chain for our other (price) oracle pallet to work properly.