### PR TITLE
fix weight

### DIFF
--- a/pallets/dia-oracle/src/weights.rs
+++ b/pallets/dia-oracle/src/weights.rs
@@ -87,7 +87,7 @@ impl<T: frame_system::Config> WeightInfo for DiaWeightInfo<T> {
 	// Storage: DiaOracle AuthorizedAccounts (r:1 w:0)
 	// Storage: DiaOracle CoinInfosMap (r:0 w:1)
 	fn set_updated_coin_infos() -> Weight {
-		Weight::from_ref_time(1_152_148_682_000)
+		Weight::from_ref_time(1_241_248_000)
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -140,7 +140,7 @@ impl WeightInfo for () {
 	// Storage: DiaOracle AuthorizedAccounts (r:1 w:0)
 	// Storage: DiaOracle CoinInfosMap (r:0 w:1)
 	fn set_updated_coin_infos() -> Weight {
-		Weight::from_ref_time(1_152_148_682_000)
+		Weight::from_ref_time(1_241_248_000)
 			.saturating_add(RocksDbWeight::get().reads(1))
 			.saturating_add(RocksDbWeight::get().writes(1))
 	}


### PR DESCRIPTION
Update weight for set price info extrinsic
more about issue:
![image](https://user-images.githubusercontent.com/102041955/221165109-c88dfeed-fc56-4481-81fa-7d3db4fe6828.png)

![image](https://user-images.githubusercontent.com/102041955/221165154-8fd2fe5a-fd5e-4a92-8d85-6f26f083487c.png)

Problem 
The [weight defined for the dispatchable function](https://github.com/pendulum-chain/oracle-pallet/blob/b8c5bd0f0e756d83868f1dd982d45792a662bfd7/pallets/dia-oracle/src/weights.rs#L89) set_updated_coin_infos represents a computation longer than one second (1^12 units of weight = 1 second of computation).

Solution: specify weight limit for extrinsic that related to 1 read and 1 write and less than one sec.