### PR TITLE
use #[pallet::call_index()] for extrinsic

### DIFF
--- a/pallets/dia-oracle/src/lib.rs
+++ b/pallets/dia-oracle/src/lib.rs
@@ -296,6 +296,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_currency())]
 		pub fn add_currency(
 			origin: OriginFor<T>,
@@ -314,6 +315,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::remove_currency())]
 		pub fn remove_currency(
 			origin: OriginFor<T>,
@@ -332,6 +334,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::authorize_account())]
 		pub fn authorize_account(origin: OriginFor<T>, account_id: T::AccountId) -> DispatchResult {
 			if let Ok(origin_account_id) = ensure_signed(origin.clone()) {
@@ -348,6 +351,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::deauthorize_account())]
 		pub fn deauthorize_account(
 			origin: OriginFor<T>,
@@ -371,6 +375,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_updated_coin_infos())]
 		pub fn set_updated_coin_infos(
 			origin: OriginFor<T>,
@@ -385,6 +390,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_batching_api())]
 		pub fn set_batching_api(origin: OriginFor<T>, api: Vec<u8>) -> DispatchResult {
 			let origin_account_id = ensure_signed(origin)?;


### PR DESCRIPTION
use `#[pallet::call_index(0)]` attribute because there is warning. it required. 
[issue 133](https://github.com/pendulum-chain/pendulum/issues/133)