### PR TITLE
Change type of `volume` to `f64`

### DIFF
--- a/dia-batching-server/src/dia.rs
+++ b/dia-batching-server/src/dia.rs
@@ -32,7 +32,7 @@ pub struct QuotedAsset {
 	#[serde(rename(deserialize = "Asset"))]
 	pub asset: Asset,
 	#[serde(rename(deserialize = "Volume"))]
-	pub volume: Decimal,
+	pub volume: f64,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -170,6 +170,13 @@ impl DiaApi for Dia {
 		&self,
 	) -> Result<Vec<QuotedAsset>, Box<dyn error::Error + Sync + Send>> {
 		let r = reqwest::get(QUOTABLE_ASSETS_ENDPOINT).await?;
-		Ok(r.json().await?)
+		let assets = match r.json::<Vec<QuotedAsset>>().await {
+			Ok(assets) => assets,
+			Err(e) => {
+				log::error!("Failed to parse quotable assets: {}", e);
+				return Err(e.into());
+			},
+		};
+		Ok(assets)
 	}
 }


### PR DESCRIPTION
The problem here is that parsing the response from the `QUOTABLE_ASSETS_ENDPOINT` (https://api.diadata.org/v1/quotedAssets) is not working.

It fails because the response of that endpoint contains a value `4656506323017036700000000000000` which is too large to fit into the [Decimal](https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html) type. It works when changing it to `f64` though. While the `f64` type will not be able to accurately hold all volumes, it works for the assets that we are interested in. I checked the resulting values for the supply of `KSM` and `XLM` and they look correct.

Closes #12. 