### PR TITLE
Add fallback to prevDay quote for polygon prices

### DIFF
--- a/dia-batching-server/src/api/polygon.rs
+++ b/dia-batching-server/src/api/polygon.rs
@@ -77,6 +77,12 @@ impl PolygonPriceApi {
 					ticker.prev_day.c
 				};
 
+				if price == 0.into() {
+					log::warn!("Price for {} is 0", symbol);
+					// We don't want to return a Quotation if the price is 0
+					continue;
+				}
+
 				// We don't have supply information for fiat currencies
 				let supply = Decimal::from(0);
 				// We use the current time as the time

--- a/dia-batching-server/src/api/polygon.rs
+++ b/dia-batching-server/src/api/polygon.rs
@@ -73,12 +73,13 @@ impl PolygonPriceApi {
 					// If the bid price is available on the last quote, we use it
 					ticker.last_quote.b
 				} else {
+					log::warn!("No bid price available for {symbol} in last quote. Falling back to quote from previous day.");
 					// Otherwise we use the close price of the previous day
 					ticker.prev_day.c
 				};
 
 				if price == 0.into() {
-					log::warn!("Price for {} is 0", symbol);
+					log::warn!("Price for {} is 0. Not returning quotation", symbol);
 					// We don't want to return a Quotation if the price is 0
 					continue;
 				}

--- a/dia-batching-server/src/api/polygon.rs
+++ b/dia-batching-server/src/api/polygon.rs
@@ -65,11 +65,18 @@ impl PolygonPriceApi {
 			prices.push(quotation);
 		}
 
-		for (ticker_name, quote) in quotes {
+		for (ticker_name, ticker) in quotes {
 			if let Some(asset) = ticker_to_asset_map.get(ticker_name.as_str()) {
 				let symbol = asset.symbol.clone();
-				// We use the bid price as the price
-				let price = quote.b;
+
+				let price = if ticker.last_quote.b > 0.into() {
+					// If the bid price is available on the last quote, we use it
+					ticker.last_quote.b
+				} else {
+					// Otherwise we use the close price of the previous day
+					ticker.prev_day.c
+				};
+
 				// We don't have supply information for fiat currencies
 				let supply = Decimal::from(0);
 				// We use the current time as the time
@@ -121,7 +128,7 @@ impl PolygonPriceApi {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PolygonPrice {
+pub struct ConversionPrice {
 	pub converted: Decimal,
 	pub from: String,
 	#[serde(rename = "initialAmount")]
@@ -134,30 +141,53 @@ pub struct PolygonPrice {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TickerQuote {
-	/// Ask price
-	pub a: Decimal,
-	/// Bid price
-	pub b: Decimal,
-	/// Timestamp (milliseconds)
-	pub t: u64,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Ticker {
-	pub ticker: String,
-	pub updated: u64,
-	#[serde(rename = "lastQuote")]
-	pub last_quote: TickerQuote,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 struct Tickers {
 	pub tickers: Vec<Ticker>,
 	pub status: String,
 }
 
-/// Polygon network client
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Ticker {
+	/// The exchange symbol that this item is traded under.
+	#[serde(rename = "ticker")]
+	pub ticker_name: String,
+	/// The last updated timestamp.
+	pub updated: u64,
+	#[serde(rename = "lastQuote")]
+	pub last_quote: LastQuote,
+	#[serde(rename = "prevDay")]
+	pub prev_day: PrevDayQuote,
+}
+
+/// The most recent quote for this ticker.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LastQuote {
+	/// The ask price
+	pub a: Decimal,
+	/// The bid price
+	pub b: Decimal,
+	/// The millisecond accuracy timestamp of the quote.
+	pub t: u64,
+}
+
+/// The previous day's bar for this ticker.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PrevDayQuote {
+	/// The close price for the symbol in the given time period.
+	pub c: Decimal,
+	/// The highest price for the symbol in the given time period.
+	pub h: Decimal,
+	/// The lowest price for the symbol in the given time period.
+	pub l: Decimal,
+	/// The open price for the symbol in the given time period.
+	pub o: Decimal,
+	/// The trading volume of the symbol in the given time period.
+	pub v: Decimal,
+	/// The volume weighted average price.
+	pub vw: Decimal,
+}
+
+/// Client to communicate with the Polygon.io API
 pub struct PolygonClient {
 	host: String,
 	api_key: String,
@@ -208,7 +238,8 @@ impl PolygonClient {
 
 	#[allow(dead_code)]
 	/// Get the current price of any fiat currency in USD
-	pub async fn price(&self, from_currency: String) -> Result<PolygonPrice, PolygonError> {
+	/// from https://polygon.io/docs/forex/get_v1_conversion__from___to
+	pub async fn price(&self, from_currency: String) -> Result<ConversionPrice, PolygonError> {
 		// Currencies have to be upper-case
 		let from_currency = from_currency.to_uppercase();
 		// We always query for USD.
@@ -225,20 +256,18 @@ impl PolygonClient {
 		self.get(&req).await
 	}
 
+	/// Get all tickers for the given from_currency_tickers
+	/// from https://polygon.io/docs/forex/get_v2_snapshot_locale_global_markets_forex_tickers
 	pub async fn all_tickers(
 		&self,
 		from_currency_tickers: &Vec<String>,
-	) -> Result<HashMap<String, TickerQuote>, PolygonError> {
+	) -> Result<HashMap<String, Ticker>, PolygonError> {
 		let from_currencies = from_currency_tickers.join(",");
 		let req =
 			format!("v2/snapshot/locale/global/markets/forex/tickers?tickers={}", from_currencies);
 
 		let tickers: Tickers = self.get(&req).await?;
-		let mut quotes = HashMap::new();
-		for ticker in tickers.tickers {
-			quotes.insert(ticker.ticker, ticker.last_quote);
-		}
-
+		let quotes = tickers.tickers.iter().map(|t| (t.ticker_name.clone(), t.clone())).collect();
 		Ok(quotes)
 	}
 
@@ -354,9 +383,15 @@ mod tests {
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "BRL-USD".to_string() };
 		let eur_asset =
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "EUR-USD".to_string() };
+		let ngn_asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "NGN-USD".to_string() };
+		let tzs_asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "TZS-USD".to_string() };
+		let aud_asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "AUD-USD".to_string() };
 		let usd_asset =
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "USD-USD".to_string() };
-		let assets = vec![&usd_asset, &brl_asset, &eur_asset];
+		let assets = vec![&usd_asset, &brl_asset, &eur_asset, &ngn_asset, &tzs_asset, &aud_asset];
 
 		let result = polygon_api.get_prices(assets.clone()).await;
 		assert!(result.is_ok());
@@ -389,5 +424,32 @@ mod tests {
 		assert_eq!(eur_price.name, eur_asset.symbol);
 		assert_eq!(eur_price.blockchain, Some("FIAT".to_string()));
 		assert!(eur_price.price > 0.into());
+
+		let ngn_price = prices
+			.iter()
+			.find(|q| q.symbol == ngn_asset.symbol)
+			.expect("Should return a NGN price");
+		assert_eq!(ngn_price.symbol, ngn_asset.symbol);
+		assert_eq!(ngn_price.name, ngn_asset.symbol);
+		assert_eq!(ngn_price.blockchain, Some("FIAT".to_string()));
+		assert!(ngn_price.price > 0.into());
+
+		let tzs_price = prices
+			.iter()
+			.find(|q| q.symbol == tzs_asset.symbol)
+			.expect("Should return a TZS price");
+		assert_eq!(tzs_price.symbol, tzs_asset.symbol);
+		assert_eq!(tzs_price.name, tzs_asset.symbol);
+		assert_eq!(tzs_price.blockchain, Some("FIAT".to_string()));
+		assert!(tzs_price.price > 0.into());
+
+		let aud_price = prices
+			.iter()
+			.find(|q| q.symbol == aud_asset.symbol)
+			.expect("Should return a AUD price");
+		assert_eq!(aud_price.symbol, aud_asset.symbol);
+		assert_eq!(aud_price.name, aud_asset.symbol);
+		assert_eq!(aud_price.blockchain, Some("FIAT".to_string()));
+		assert!(aud_price.price > 0.into());
 	}
 }

--- a/dia-batching-server/src/price_updater.rs
+++ b/dia-batching-server/src/price_updater.rs
@@ -49,9 +49,6 @@ fn convert_to_coin_info(value: Quotation) -> Result<CoinInfo, Box<dyn Error + Sy
 		supply,
 	};
 
-	info!("Coin Price: {:#?}", price);
-	info!("Coin Info : {:#?}", coin_info);
-
 	Ok(coin_info)
 }
 


### PR DESCRIPTION
Amends the changes made in #21.

- Adds a fallback to the `prevDay` quote in case the `lastQuote` does not contain any non-zero values.
- Does not return a quotation if the price is 0, so that the off-chain worker does not feed 'invalid' price data to the chain. 

I noticed that the batching server returns a price of `0` for the TZS and NGN currencies. This is because the `lastQuote` returned by the 'all-tickers' endpoint returns 0 values for all fields of those currencies. I suppose this is either because there is not much activity or maybe they were not traded on that day yet, see 
https://api.polygon.io/v2/snapshot/locale/global/markets/forex/tickers?tickers=C:TZSUSD&apiKey={apiKey}.

<img width="485" alt="image" src="https://github.com/pendulum-chain/oracle-pallet/assets/6690623/b5104db5-933f-4d29-b535-a7ace4eceda5">

In case the `lastQuote` is empty we will now fall back to the `prevDay` values instead. 

I compared them to the response of the currency-conversion endpoint here 
https://api.polygon.io/v1/conversion/TZS/USD?amount=1&precision=5&apiKey={apiKey}

and I think using the `c` (-> 'close') value of the previous day makes the most sense in this case. It also matches the result of the conversion (though to be fair, all values seem to do in this example due to the low precision).
<img width="405" alt="image" src="https://github.com/pendulum-chain/oracle-pallet/assets/6690623/33e36995-8703-4ee3-a3cc-d5f8dbc6df9a">
