### PR TITLE
Configure CORS for accessing batching server from Pendulum portal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e772b3bcafe335042b5db010ab7c09013dad6eac4915c91d8d50902769f331"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1292,7 @@ dependencies = [
 name = "dia-batching-server"
 version = "0.1.0"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "arc-swap",
  "async-trait",

--- a/dia-batching-server/Cargo.toml
+++ b/dia-batching-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "4.8.0"
+actix-cors = "0.7.0"
 arc-swap = "1.7.1"
 async-trait = "0.1.80"
 


### PR DESCRIPTION
Adds a CORS configuration to the batching server so that the only allowed origin is the production domain of the portal.

Closes #27.