### PR TITLE
Enable price feeds for pen and ars on batching server

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,8 +37,3 @@ jobs:
       - name: Check Build
         run: |
           SKIP_WASM_BUILD=1 cargo check --release
-
-      - name: Check Build for Benchmarking
-        run: >
-          pushd node &&
-          cargo check --features=runtime-benchmarks --release

--- a/dia-batching-server/src/api/polygon.rs
+++ b/dia-batching-server/src/api/polygon.rs
@@ -396,9 +396,13 @@ mod tests {
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "TZS-USD".to_string() };
 		let aud_asset =
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "AUD-USD".to_string() };
+		let ars_asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "ARS-USD".to_string() };
+		let pen_asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "PEN-USD".to_string() };
 		let usd_asset =
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "USD-USD".to_string() };
-		let assets = vec![&usd_asset, &brl_asset, &eur_asset, &ngn_asset, &tzs_asset, &aud_asset];
+		let assets = vec![&usd_asset, &brl_asset, &eur_asset, &ngn_asset, &tzs_asset, &aud_asset, &ars_asset, &pen_asset];
 
 		let result = polygon_api.get_prices(assets.clone()).await;
 		assert!(result.is_ok());
@@ -458,5 +462,23 @@ mod tests {
 		assert_eq!(aud_price.name, aud_asset.symbol);
 		assert_eq!(aud_price.blockchain, Some("FIAT".to_string()));
 		assert!(aud_price.price > 0.into());
+
+		let ars_price = prices
+			.iter()
+			.find(|q| q.symbol == ars_asset.symbol)
+			.expect("Should return a ARS price");
+		assert_eq!(ars_price.symbol, ars_asset.symbol);
+		assert_eq!(ars_price.name, ars_asset.symbol);
+		assert_eq!(ars_price.blockchain, Some("FIAT".to_string()));
+		assert!(ars_price.price > 0.into());
+
+		let pen_price = prices
+			.iter()
+			.find(|q| q.symbol == pen_asset.symbol)
+			.expect("Should return a PEN price");
+		assert_eq!(pen_price.symbol, pen_asset.symbol);
+		assert_eq!(pen_price.name, pen_asset.symbol);
+		assert_eq!(pen_price.blockchain, Some("FIAT".to_string()));
+		assert!(pen_price.price > 0.into());
 	}
 }

--- a/dia-batching-server/src/args.rs
+++ b/dia-batching-server/src/args.rs
@@ -25,7 +25,7 @@ pub struct DiaApiArgs {
 	#[clap(short, long,
         parse(from_str = parse_currency_vec),
 		env = "SUPPORTED_CURRENCIES",
-        default_value = "FIAT:USD-USD,FIAT:EUR-USD,FIAT:BRL-USD,FIAT:AUD-USD,FIAT:NGN-USD,FIAT:TZS-USD,Pendulum:PEN,Amplitude:AMPE,Polkadot:DOT,Kusama:KSM,Astar:ASTR,Bifrost:BNC,Bifrost:vDOT,HydraDX:HDX,Moonbeam:GLMR,Polkadex:PDEX,Stellar:XLM,Picasso:PICA"
+        default_value = "FIAT:USD-USD,FIAT:EUR-USD,FIAT:BRL-USD,FIAT:AUD-USD,FIAT:NGN-USD,FIAT:TZS-USD,FIAT:PEN-USD,FIAT:ARS-USD,Pendulum:PEN,Amplitude:AMPE,Polkadot:DOT,Kusama:KSM,Astar:ASTR,Bifrost:BNC,Bifrost:vDOT,HydraDX:HDX,Moonbeam:GLMR,Polkadex:PDEX,Stellar:XLM,Picasso:PICA"
     )]
 	pub supported_currencies: SupportedCurrencies,
 


### PR DESCRIPTION
The redeployment of the batching server is automatically triggered when this PR is merged.
Since the batching server is now using the default value for the supported currencies, the code changes here should be enough to complete #30.

Closes #30.