### PR TITLE
Add custom handling for argentinian blue dollar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,7 +2046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50cfdc7f34b7f01909d55c2dcb71d4c13cbcbb4a1605d6c8bd760d654c1144b"
 dependencies = [
  "graphql_query_derive",
- "reqwest 0.11.20",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
 ]
@@ -3673,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3695,9 +3695,12 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3735,11 +3738,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3912,6 +3915,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -4119,18 +4131,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4908,6 +4920,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"

--- a/dia-batching-server/src/api/binance.rs
+++ b/dia-batching-server/src/api/binance.rs
@@ -31,7 +31,7 @@ impl BinancePriceApi {
 			}),
 			Err(error) => {
 				log::warn!("Error getting price for {:?} from Binance: {:?}", asset, error);
-				Err(BinanceError(format!("Could not get price for {:?}", asset)))
+				Err(error)
 			},
 		}
 	}

--- a/dia-batching-server/src/api/binance.rs
+++ b/dia-batching-server/src/api/binance.rs
@@ -1,0 +1,115 @@
+use crate::api::error::BinanceError;
+use crate::types::{AssetSpecifier, Quotation};
+use chrono::Utc;
+use rust_decimal::prelude::Zero;
+use rust_decimal::Decimal;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+pub struct BinancePriceApi {
+	client: BinanceClient,
+}
+
+impl BinancePriceApi {
+	pub fn new() -> Self {
+		let client: BinanceClient = BinanceClient::default();
+
+		Self { client }
+	}
+
+	pub async fn get_price(&self, asset: &AssetSpecifier) -> Result<Quotation, BinanceError> {
+		let binance_asset_identifier = Self::convert_to_binance_id(&asset);
+
+		match self.client.price(binance_asset_identifier).await {
+			Ok(price) => Ok(Quotation {
+				symbol: asset.symbol.clone(),
+				name: asset.symbol.clone(),
+				blockchain: Some(asset.blockchain.clone().into()),
+				price: price.price,
+				supply: Decimal::zero(),
+				time: Utc::now().timestamp().unsigned_abs(),
+			}),
+			Err(error) => {
+				log::warn!("Error getting price for {:?} from Binance: {:?}", asset, error);
+				Err(BinanceError(format!("Could not get price for {:?}", asset)))
+			},
+		}
+	}
+
+	// We assume here that the `symbol` field of the `AssetSpecifier` is a valid asset for Binance.
+	// The `blockchain` field is not used and ignored.
+	fn convert_to_binance_id(asset: &AssetSpecifier) -> String {
+		asset.symbol.to_uppercase()
+	}
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BinancePrice {
+	pub symbol: String,
+	pub price: Decimal,
+}
+
+pub struct BinanceClient {
+	host: String,
+	inner: reqwest::Client,
+}
+
+impl BinanceClient {
+	pub fn default() -> Self {
+		Self::new("https://api.binance.com".to_string())
+	}
+
+	pub fn new(host: String) -> Self {
+		let inner = reqwest::Client::new();
+
+		Self { host, inner }
+	}
+
+	async fn get<R: DeserializeOwned>(&self, endpoint: &str) -> Result<R, BinanceError> {
+		let url = reqwest::Url::parse(
+			format!("{host}/{ep}", host = self.host.as_str(), ep = endpoint).as_str(),
+		)
+		.expect("Invalid URL");
+
+		let response = self
+			.inner
+			.get(url)
+			.send()
+			.await
+			.map_err(|e| BinanceError(format!("Failed to send request: {}", e.to_string())))?;
+
+		if !response.status().is_success() {
+			let result = response.text().await;
+			return Err(BinanceError(format!(
+				"Binance API error: {}",
+				result.unwrap_or("Unknown".to_string()).trim()
+			)));
+		}
+
+		let result = response.json().await;
+		result.map_err(|e| BinanceError(format!("Could not decode Binance response: {}", e)))
+	}
+
+	pub async fn price(&self, symbol: String) -> Result<BinancePrice, BinanceError> {
+		let endpoint = format!("api/v3/ticker/price?symbol={}", symbol);
+		let response: BinancePrice = self.get(&endpoint).await?;
+		Ok(response)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[tokio::test]
+	async fn test_fetching_single_price() {
+		let client = BinanceClient::default();
+
+		let id = "USDTARS";
+
+		let price = client.price(id.to_string()).await.expect("Should return a price");
+
+		assert_eq!(price.symbol, id);
+		assert!(price.price > 0.into());
+	}
+}

--- a/dia-batching-server/src/api/coingecko.rs
+++ b/dia-batching-server/src/api/coingecko.rs
@@ -320,10 +320,9 @@ mod tests {
 
 		// Check if all assets have a quotation and if not, print the missing ones
 		for asset in assets {
-			let quotation = quotations
-				.iter()
-				.find(|q| q.symbol == asset.symbol)
-				.expect(format!("Could not find a quotation for asset specifier {:?}", asset).as_str());
+			let quotation = quotations.iter().find(|q| q.symbol == asset.symbol).expect(
+				format!("Could not find a quotation for asset specifier {:?}", asset).as_str(),
+			);
 			assert_eq!(quotation.symbol, asset.symbol);
 			assert_eq!(quotation.name, asset.symbol);
 			assert_eq!(quotation.blockchain, Some(asset.blockchain.clone()));

--- a/dia-batching-server/src/api/custom/ampe.rs
+++ b/dia-batching-server/src/api/custom/ampe.rs
@@ -4,8 +4,8 @@ use crate::types::{AssetSpecifier, Quotation};
 use async_trait::async_trait;
 use chrono::Utc;
 use graphql_client::{GraphQLQuery, Response};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::Zero;
+use rust_decimal::Decimal;
 
 // The blockchain and symbol for the Amplitude native token
 // These are the expected values for the asset specifier.
@@ -92,8 +92,10 @@ mod tests {
 		let asset =
 			AssetSpecifier { blockchain: "Amplitude".to_string(), symbol: "AMPE".to_string() };
 
-		let ampe_quotation =
-			CustomPriceApi::get_price(&asset).await.expect("should return a quotation");
+		let ampe_quotation = CustomPriceApi::new()
+			.get_price(&asset)
+			.await
+			.expect("should return a quotation");
 
 		assert_eq!(ampe_quotation.symbol, asset.symbol);
 		assert_eq!(ampe_quotation.name, asset.symbol);

--- a/dia-batching-server/src/api/custom/arsb.rs
+++ b/dia-batching-server/src/api/custom/arsb.rs
@@ -1,0 +1,73 @@
+use crate::api::binance::BinancePriceApi;
+use crate::api::custom::AssetCompatibility;
+use crate::api::error::CustomError;
+use crate::types::{AssetSpecifier, Quotation};
+use async_trait::async_trait;
+use chrono::Utc;
+use rust_decimal::prelude::Zero;
+use rust_decimal::Decimal;
+
+// The blockchain and symbol for the Argentinian blue dollar.
+// These are the expected values for the asset specifier.
+pub const BLOCKCHAIN: &'static str = "FIAT";
+pub const SYMBOL: &'static str = "ARS-USD";
+
+/// Returns the price for the Argentinian blue dollar.
+/// The price is fetched from Binance as binance has a very accurate price for the blue dollar.
+pub struct ArsBluePriceView;
+
+#[async_trait]
+impl AssetCompatibility for ArsBluePriceView {
+	fn supports(&self, asset: &AssetSpecifier) -> bool {
+		asset.blockchain.to_uppercase() == BLOCKCHAIN && asset.symbol.to_uppercase() == SYMBOL
+	}
+
+	async fn get_price(&self, _asset: &AssetSpecifier) -> Result<Quotation, CustomError> {
+		ArsBluePriceView::get_price().await
+	}
+}
+
+impl ArsBluePriceView {
+	async fn get_price() -> Result<Quotation, CustomError> {
+		// Only the symbol is needed to get the price with the BinancePriceApi client.
+		let asset =
+			AssetSpecifier { blockchain: "Binance".to_string(), symbol: "USDTARS".to_string() };
+
+		let binance_price_api = BinancePriceApi::new();
+		// The direction of the conversion is ARS -> USDT
+		let usdt_ars_price = binance_price_api
+			.get_price(&asset)
+			.await
+			.map_err(|e| CustomError(format!("Failed to get price: {:?}", e)))?
+			.price;
+
+		// We need to convert the price from USD -> ARS though so we invert
+		let ars_usdt_price =
+			Decimal::from(1).checked_div(usdt_ars_price).unwrap_or(Decimal::zero());
+
+		Ok(Quotation {
+			symbol: SYMBOL.to_string(),
+			name: SYMBOL.to_string(),
+			blockchain: Some(BLOCKCHAIN.to_string()),
+			price: ars_usdt_price,
+			supply: Decimal::zero(),
+			time: Utc::now().timestamp().unsigned_abs(),
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ArsBluePriceView, BLOCKCHAIN, SYMBOL};
+
+	#[tokio::test]
+	async fn test_get_arsb_price_from_view() {
+		let arsb_quotation =
+			ArsBluePriceView::get_price().await.expect("should return a quotation");
+
+		assert_eq!(arsb_quotation.symbol, SYMBOL);
+		assert_eq!(arsb_quotation.name, SYMBOL);
+		assert_eq!(arsb_quotation.blockchain.expect("should return something"), BLOCKCHAIN);
+		assert!(arsb_quotation.price > 0.into());
+	}
+}

--- a/dia-batching-server/src/api/custom/mod.rs
+++ b/dia-batching-server/src/api/custom/mod.rs
@@ -1,0 +1,46 @@
+use crate::api::error::CustomError;
+use crate::types::Quotation;
+use crate::AssetSpecifier;
+use async_trait::async_trait;
+use std::string::ToString;
+
+mod ampe;
+mod arsb;
+
+use ampe::AmpePriceView;
+use arsb::ArsBluePriceView;
+
+#[async_trait]
+pub trait AssetCompatibility: Send {
+	fn supports(&self, asset: &AssetSpecifier) -> bool;
+
+	async fn get_price(&self, asset: &AssetSpecifier) -> Result<Quotation, CustomError>;
+}
+
+pub struct CustomPriceApi;
+
+impl CustomPriceApi {
+	pub async fn get_price(asset: &AssetSpecifier) -> Result<Quotation, CustomError> {
+		let api =
+			Self::get_supported_api(asset).ok_or(CustomError("Unsupported asset".to_string()))?;
+		api.get_price(asset).await
+	}
+
+	pub fn is_supported(asset: &AssetSpecifier) -> bool {
+		Self::get_supported_api(asset).is_some()
+	}
+
+	/// Iterates over all supported APIs and returns the first one that supports the given asset.
+	fn get_supported_api(asset: &AssetSpecifier) -> Option<Box<dyn AssetCompatibility>> {
+		let compatible_apis: Vec<Box<dyn AssetCompatibility>> =
+			vec![Box::new(AmpePriceView), Box::new(ArsBluePriceView)];
+
+		for api in compatible_apis {
+			if api.supports(asset) {
+				return Some(api);
+			}
+		}
+
+		None
+	}
+}

--- a/dia-batching-server/src/api/error.rs
+++ b/dia-batching-server/src/api/error.rs
@@ -38,3 +38,16 @@ impl fmt::Display for PolygonError {
 		write!(f, "{}", err_msg)
 	}
 }
+
+#[derive(Debug)]
+pub struct BinanceError(pub String);
+
+impl fmt::Display for BinanceError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		let BinanceError(ref err_msg) = *self;
+		// Log the error message
+		log::error!("BinanceError: {}", err_msg);
+		// Write the error message to the formatter
+		write!(f, "{}", err_msg)
+	}
+}

--- a/dia-batching-server/src/api/mod.rs
+++ b/dia-batching-server/src/api/mod.rs
@@ -8,6 +8,7 @@ use crate::AssetSpecifier;
 use async_trait::async_trait;
 use clap::Parser;
 
+mod binance;
 mod coingecko;
 mod custom;
 mod error;

--- a/dia-batching-server/src/api/mod.rs
+++ b/dia-batching-server/src/api/mod.rs
@@ -42,20 +42,7 @@ impl PriceApi for PriceApiImpl {
 	async fn get_quotations(&self, assets: Vec<&AssetSpecifier>) -> Vec<Quotation> {
 		let mut quotations = Vec::new();
 
-		// First, get fiat quotations
-		let fiat_assets: Vec<_> = assets
-			.clone()
-			.into_iter()
-			.filter(|asset| PolygonPriceApi::is_supported(asset))
-			.collect();
-
-		let fiat_quotes = self.get_fiat_quotations(fiat_assets.clone()).await;
-		match fiat_quotes {
-			Ok(fiat_quotes) => quotations.extend(fiat_quotes),
-			Err(e) => log::error!("Error getting fiat quotations: {}", e),
-		}
-
-		// Then, get quotations for custom assets
+		// Get supported custom assets
 		let custom_assets: Vec<&AssetSpecifier> = assets
 			.clone()
 			.into_iter()
@@ -68,7 +55,24 @@ impl PriceApi for PriceApiImpl {
 			Err(e) => log::error!("Error getting custom quotations: {}", e),
 		}
 
-		// Finally, get supported crypto quotations
+		// Remove custom assets from the list of assets. This is important because it could happen that
+		// a custom asset is also supported by the Polygon or Coingecko API. In this case, we want to
+		// use the custom asset and not the other API.
+		let assets: Vec<&AssetSpecifier> =
+			assets.into_iter().filter(|asset| !custom_assets.contains(&asset)).collect();
+
+		let fiat_assets: Vec<_> = assets
+			.clone()
+			.into_iter()
+			.filter(|asset| PolygonPriceApi::is_supported(asset))
+			.collect();
+
+		let fiat_quotes = self.get_fiat_quotations(fiat_assets.clone()).await;
+		match fiat_quotes {
+			Ok(fiat_quotes) => quotations.extend(fiat_quotes),
+			Err(e) => log::error!("Error getting fiat quotations: {}", e),
+		}
+
 		let crypto_assets = assets
 			.into_iter()
 			.filter(|asset| CoingeckoPriceApi::is_supported(asset))

--- a/dia-batching-server/src/api/mod.rs
+++ b/dia-batching-server/src/api/mod.rs
@@ -26,6 +26,7 @@ pub trait PriceApi {
 pub struct PriceApiImpl {
 	coingecko_price_api: CoingeckoPriceApi,
 	polygon_price_api: PolygonPriceApi,
+	custom_price_api: CustomPriceApi,
 }
 
 impl PriceApiImpl {
@@ -33,6 +34,7 @@ impl PriceApiImpl {
 		Self {
 			coingecko_price_api: CoingeckoPriceApi::new_from_config(CoingeckoConfig::parse()),
 			polygon_price_api: PolygonPriceApi::new_from_config(PolygonConfig::parse()),
+			custom_price_api: CustomPriceApi::new(),
 		}
 	}
 }
@@ -46,7 +48,7 @@ impl PriceApi for PriceApiImpl {
 		let custom_assets: Vec<&AssetSpecifier> = assets
 			.clone()
 			.into_iter()
-			.filter(|asset| CustomPriceApi::is_supported(asset))
+			.filter(|asset| self.custom_price_api.is_supported(asset))
 			.collect();
 
 		let custom_quotes = self.get_custom_quotations(custom_assets.clone()).await;
@@ -111,7 +113,7 @@ impl PriceApiImpl {
 	) -> Result<Vec<Quotation>, CustomError> {
 		let mut quotations = Vec::new();
 		for asset in assets {
-			let quotation = CustomPriceApi::get_price(asset).await?;
+			let quotation = self.custom_price_api.get_price(asset).await?;
 			quotations.push(quotation);
 		}
 		Ok(quotations)

--- a/dia-batching-server/src/api/polygon.rs
+++ b/dia-batching-server/src/api/polygon.rs
@@ -402,7 +402,10 @@ mod tests {
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "PEN-USD".to_string() };
 		let usd_asset =
 			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "USD-USD".to_string() };
-		let assets = vec![&usd_asset, &brl_asset, &eur_asset, &ngn_asset, &tzs_asset, &aud_asset, &ars_asset, &pen_asset];
+		let assets = vec![
+			&usd_asset, &brl_asset, &eur_asset, &ngn_asset, &tzs_asset, &aud_asset, &ars_asset,
+			&pen_asset,
+		];
 
 		let result = polygon_api.get_prices(assets.clone()).await;
 		assert!(result.is_ok());

--- a/dia-batching-server/src/main.rs
+++ b/dia-batching-server/src/main.rs
@@ -59,7 +59,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 	let port = args.port;
 	println!("Running dia-batching-server on port {port}... (Press CTRL+C to quit)");
 	HttpServer::new(move || {
-		let cors = Cors::default().allowed_origin("https://portal.pendulumchain.org")
+		let cors = Cors::default()
+			.allowed_origin("https://portal.pendulumchain.org")
 			.allowed_methods(vec!["POST"])
 			.allowed_headers(vec!["Content-Type"])
 			.max_age(3600);


### PR DESCRIPTION
- Creates a new directory `custom` that holds the implementation of the custom handler for the AMPE and ARS-USD (blue dollar) rate
- Adds an implementation for the binance API. Binance only rate limits per IP, and many public endpoints don't even require an API key so the implementation of the Binance client does not allow passing that. The endpoint for the price is documented [here](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/public-api-endpoints#symbol-price-ticker).
- To make sure that the FIAT:ARS-USD `AssetSpecifier` will receive a quotation from the custom handler (blue dollar) and not a fiat price from polygon, the supported custom assets are filtered from the list before passing it to the fiat and crypto handler in `dia-batching-server/src/api/mod.rs`

Closes #32. 