### PR TITLE
Fix AMPE price not returned from batching server

### DIFF
--- a/dia-batching-server/src/api/custom/ampe.rs
+++ b/dia-batching-server/src/api/custom/ampe.rs
@@ -25,7 +25,7 @@ pub struct AmpePriceView;
 #[async_trait]
 impl AssetCompatibility for AmpePriceView {
 	fn supports(&self, asset: &AssetSpecifier) -> bool {
-		asset.blockchain.to_uppercase() == BLOCKCHAIN && asset.symbol.to_uppercase() == SYMBOL
+		asset.blockchain.to_uppercase() == BLOCKCHAIN.to_uppercase() && asset.symbol.to_uppercase() == SYMBOL.to_uppercase()
 	}
 
 	async fn get_price(&self, _asset: &AssetSpecifier) -> Result<Quotation, CustomError> {

--- a/dia-batching-server/src/api/custom/arsb.rs
+++ b/dia-batching-server/src/api/custom/arsb.rs
@@ -21,7 +21,7 @@ pub struct ArsBluePriceView {
 #[async_trait]
 impl AssetCompatibility for ArsBluePriceView {
 	fn supports(&self, asset: &AssetSpecifier) -> bool {
-		asset.blockchain.to_uppercase() == BLOCKCHAIN && asset.symbol.to_uppercase() == SYMBOL
+		asset.blockchain.to_uppercase() == BLOCKCHAIN.to_uppercase() && asset.symbol.to_uppercase() == SYMBOL.to_uppercase()
 	}
 
 	async fn get_price(&self, _asset: &AssetSpecifier) -> Result<Quotation, CustomError> {


### PR DESCRIPTION
The AMPE price is currently not returned from the batching server. The problem is that the comparison in the `supports()` function turns the supplied `blockchain` field of the `AssetSpecifier` to uppercase letters but the `BLOCKCHAIN` constant defined in the same file is not in uppercase letters. To make it a little more foolproof, I added the `to_uppercase()` call to both sides of the comparison. This way, we don't need to keep in mind that the constants should be defined in uppercase letters. 