### PR TITLE
Use binance for BRL rate

### DIFF
--- a/dia-batching-server/src/api/custom/brl.rs
+++ b/dia-batching-server/src/api/custom/brl.rs
@@ -1,0 +1,105 @@
+use crate::api::binance::BinancePriceApi;
+use crate::api::custom::AssetCompatibility;
+use crate::api::error::CustomError;
+use crate::types::{AssetSpecifier, Quotation};
+use async_trait::async_trait;
+use chrono::Utc;
+use rust_decimal::prelude::Zero;
+use rust_decimal::Decimal;
+
+// The blockchain and symbol for the Argentinian blue dollar.
+// These are the expected values for the asset specifier.
+pub const BLOCKCHAIN: &'static str = "FIAT";
+pub const SYMBOL: &'static str = "BRL-USD";
+
+// The basis point reduction for the price. This is used to reduce the price by 6 basis points (0.06%).
+const BPS_REDUCTION: u32 = 6;
+
+/// Returns the price for the Argentinian blue dollar.
+/// The price is fetched from Binance as binance has a very accurate price for the blue dollar.
+pub struct BrlBluePriceView {
+	binance_price_api: BinancePriceApi,
+}
+
+#[async_trait]
+impl AssetCompatibility for BrlBluePriceView {
+	fn supports(&self, asset: &AssetSpecifier) -> bool {
+		asset.blockchain.to_uppercase() == BLOCKCHAIN.to_uppercase() && asset.symbol.to_uppercase() == SYMBOL.to_uppercase()
+	}
+
+	async fn get_price(&self, _asset: &AssetSpecifier) -> Result<Quotation, CustomError> {
+		self.get_price().await
+	}
+}
+
+impl BrlBluePriceView {
+	pub fn new() -> Self {
+		BrlBluePriceView { binance_price_api: BinancePriceApi::new() }
+	}
+
+	async fn get_price(&self) -> Result<Quotation, CustomError> {
+		// Only the symbol is needed to get the price with the BinancePriceApi client.
+		let asset =
+			AssetSpecifier { blockchain: "Binance".to_string(), symbol: "USDTBRL".to_string() };
+
+		// The direction of the conversion is BRL -> USDT
+		let usdt_brl_price = self
+			.binance_price_api
+			.get_price(&asset)
+			.await
+			.map_err(|e| CustomError(format!("Failed to get price: {:?}", e)))?
+			.price;
+
+		// We need to convert the price from USD -> BRL though so we invert
+		let brl_usdt_price =
+			Decimal::from(1).checked_div(usdt_brl_price).unwrap_or(Decimal::zero());
+
+		// Apply the basis point reduction to the price
+		let brl_usdt_price = brl_usdt_price
+			.checked_sub(brl_usdt_price * Decimal::from(BPS_REDUCTION) / Decimal::from(10_000))
+			.unwrap_or(Decimal::zero());
+
+		Ok(Quotation {
+			symbol: SYMBOL.to_string(),
+			name: SYMBOL.to_string(),
+			blockchain: Some(BLOCKCHAIN.to_string()),
+			price: brl_usdt_price,
+			supply: Decimal::zero(),
+			time: Utc::now().timestamp().unsigned_abs(),
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::api::custom::CustomPriceApi;
+	use crate::types::AssetSpecifier;
+	use super::{BrlBluePriceView, BLOCKCHAIN, SYMBOL};
+
+	#[tokio::test]
+	async fn test_get_brl_price_from_api() {
+		let asset =
+			AssetSpecifier { blockchain: "FIAT".to_string(), symbol: "BRL-USD".to_string() };
+
+		let brl_quotation = CustomPriceApi::new()
+			.get_price(&asset)
+			.await
+			.expect("should return a quotation");
+
+		assert_eq!(brl_quotation.symbol, asset.symbol);
+		assert_eq!(brl_quotation.name, asset.symbol);
+		assert_eq!(brl_quotation.blockchain.expect("should return something"), asset.blockchain);
+		assert!(brl_quotation.price > 0.into());
+	}
+
+	#[tokio::test]
+	async fn test_get_brlb_price_from_view() {
+		let brlb_quotation =
+			BrlBluePriceView::new().get_price().await.expect("should return a quotation");
+
+		assert_eq!(brlb_quotation.symbol, SYMBOL);
+		assert_eq!(brlb_quotation.name, SYMBOL);
+		assert_eq!(brlb_quotation.blockchain.expect("should return something"), BLOCKCHAIN);
+		assert!(brlb_quotation.price > 0.into());
+	}
+}

--- a/dia-batching-server/src/api/custom/mod.rs
+++ b/dia-batching-server/src/api/custom/mod.rs
@@ -6,9 +6,11 @@ use std::string::ToString;
 
 mod ampe;
 mod arsb;
+mod brl;
 
 use ampe::AmpePriceView;
 use arsb::ArsBluePriceView;
+use brl::BrlBluePriceView;
 
 #[async_trait]
 pub trait AssetCompatibility: Send + Sync {
@@ -23,7 +25,13 @@ pub struct CustomPriceApi {
 
 impl CustomPriceApi {
 	pub fn new() -> Self {
-		CustomPriceApi { apis: vec![Box::new(AmpePriceView), Box::new(ArsBluePriceView::new())] }
+		CustomPriceApi {
+			apis: vec![
+				Box::new(AmpePriceView),
+				Box::new(ArsBluePriceView::new()),
+				Box::new(BrlBluePriceView::new()),
+			],
+		}
 	}
 
 	pub async fn get_price(&self, asset: &AssetSpecifier) -> Result<Quotation, CustomError> {


### PR DESCRIPTION
This pull request introduces functionality to fetch and process the price of the Brazilian blue dollar (BRL-USD) within the `dia-batching-server` project. It includes the addition of a new price view, integration into the existing custom price API, and corresponding unit tests to ensure reliability.

### Addition of BRL-USD Price View:

* [`dia-batching-server/src/api/custom/brl.rs`](diffhunk://#diff-a0bbd479ead5356e32050b52b034d6057712f994163811678822c82c620e93c1R1-R87): Added `BrlBluePriceView`, a new price view for fetching the Brazilian blue dollar price using Binance's API. It includes logic for price inversion (BRL -> USD) and a basis point reduction for accuracy. Unit tests were added to validate functionality.

### Integration into Custom Price API:

* `dia-batching-server/src/api/custom/mod.rs`: 
  - Registered `BrlBluePriceView` in the module imports to make it accessible.
  - Updated `CustomPriceApi` to include `BrlBluePriceView` in its list of supported APIs, enabling it to process BRL-USD price requests.