### PR TITLE
Remove basis point reduction logic from BRL-USD price calculation

### DIFF
--- a/dia-batching-server/src/api/custom/brl.rs
+++ b/dia-batching-server/src/api/custom/brl.rs
@@ -12,9 +12,6 @@ use rust_decimal::Decimal;
 pub const BLOCKCHAIN: &'static str = "FIAT";
 pub const SYMBOL: &'static str = "BRL-USD";
 
-// The basis point reduction for the price. This is used to adjust the price to a more favorable rate for the user.
-const BPS_REDUCTION: u32 = 5;
-
 /// Returns the price for the Argentinian blue dollar.
 /// The price is fetched from Binance as binance has a very accurate price for the blue dollar.
 pub struct BrlBluePriceView {
@@ -50,20 +47,9 @@ impl BrlBluePriceView {
 			.map_err(|e| CustomError(format!("Failed to get price: {:?}", e)))?
 			.price;
 
-
-		// Apply the basis point reduction to the price (to the USDT->BRL price, resulting in a favorable buy price for the user)
-		// let usdt_brl_price = usdt_brl_price
-		// 	.checked_sub(usdt_brl_price * Decimal::from(BPS_REDUCTION) / Decimal::from(10_000))
-		// 	.unwrap_or(Decimal::zero());
-
 		// We need to convert the price from USD -> BRL though so we invert
 		let brl_usdt_price =
 			Decimal::from(1).checked_div(usdt_brl_price).unwrap_or(Decimal::zero());
-
-		// Apply the basis point reduction to the price (to the BRL->USD price, resulting in a favorable sell price for the user)
-		let brl_usdt_price = brl_usdt_price
-			.checked_sub(brl_usdt_price * Decimal::from(BPS_REDUCTION) / Decimal::from(10_000))
-			.unwrap_or(Decimal::zero());
 
 		Ok(Quotation {
 			symbol: SYMBOL.to_string(),


### PR DESCRIPTION
This pull request removes the basis point reduction logic from the BRL price calculation in the `brl.rs` API. The code that previously adjusted the price to be more favorable for the user by reducing it by a certain number of basis points has been deleted.

Price calculation changes:

* Removed the `BPS_REDUCTION` constant and all related logic that applied a basis point reduction to the BRL-USD price in `BrlBluePriceView`. [[1]](diffhunk://#diff-a0bbd479ead5356e32050b52b034d6057712f994163811678822c82c620e93c1L15-L17) [[2]](diffhunk://#diff-a0bbd479ead5356e32050b52b034d6057712f994163811678822c82c620e93c1L53-L67)